### PR TITLE
Using promauto to initialize the metric and testutil in tests

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"github.com/eko/gocache/codec"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 const (
@@ -20,7 +21,7 @@ type Prometheus struct {
 }
 
 func initCacheCollector(namespace string) *prometheus.GaugeVec {
-	c := prometheus.NewGaugeVec(
+	c := promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name:      "collector",
 			Namespace: namespace,
@@ -28,7 +29,6 @@ func initCacheCollector(namespace string) *prometheus.GaugeVec {
 		},
 		[]string{"service", "store", "metric"},
 	)
-	prometheus.MustRegister(c)
 	return c
 }
 

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -7,7 +7,7 @@ import (
 	mocksCodec "github.com/eko/gocache/test/mocks/codec"
 	mocksStore "github.com/eko/gocache/test/mocks/store"
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,11 +33,13 @@ func TestRecord(t *testing.T) {
 	metrics.Record("redis", "hit_count", 6)
 
 	// Then
-	dtoMetric := &dto.Metric{}
-	metric, _ := metrics.collector.GetMetricWithLabelValues("my-test-service-name", "redis", "hit_count")
-	metric.Write(dtoMetric)
+	metric, err := metrics.collector.GetMetricWithLabelValues("my-test-service-name", "redis", "hit_count")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	v := testutil.ToFloat64(metric)
 
-	assert.Equal(t, float64(6), dtoMetric.GetGauge().GetValue())
+	assert.Equal(t, float64(6), v)
 }
 
 func TestRecordFromCodec(t *testing.T) {
@@ -105,10 +107,12 @@ func TestRecordFromCodec(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		dtoMetric := &dto.Metric{}
-		metric, _ := metrics.collector.GetMetricWithLabelValues("my-test-service-name", "redis", tc.metricName)
-		metric.Write(dtoMetric)
+		metric, err := metrics.collector.GetMetricWithLabelValues("my-test-service-name", "redis", tc.metricName)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		v := testutil.ToFloat64(metric)
 
-		assert.Equal(t, tc.expected, dtoMetric.GetGauge().GetValue())
+		assert.Equal(t, tc.expected, v)
 	}
 }


### PR DESCRIPTION
Hi!
First of all I really like the idea for the project you are building here, and thank you for doing that!  
While browsing through the source code I noticed that you could be some additional parts of `prometheus` repo to  make the integration more straight forward. I added the use of `promauto` since it is way too easy to forget the call to register.

I also added the `testutil` package for unit tests to be more explicit with checking the metric value. 

Let me know what you think of the changes.