### PR TITLE
Fix redis tags: redis client is returning strings

### DIFF
--- a/store/redis_test.go
+++ b/store/redis_test.go
@@ -101,12 +101,12 @@ func TestRedisSetWithTags(t *testing.T) {
 	defer ctrl.Finish()
 
 	cacheKey := "my-key"
-	cacheValue := []byte("my-cache-value")
+	cacheValue := "my-cache-value"
 
 	client := mocksStore.NewMockRedisClientInterface(ctrl)
 	client.EXPECT().Set(cacheKey, cacheValue, time.Duration(0)).Return(&redis.StatusCmd{})
 	client.EXPECT().Get("gocache_tag_tag1").Return(&redis.StringCmd{})
-	client.EXPECT().Set("gocache_tag_tag1", []byte("my-key"), 720*time.Hour).Return(&redis.StatusCmd{})
+	client.EXPECT().Set("gocache_tag_tag1", "my-key", 720*time.Hour).Return(&redis.StatusCmd{})
 
 	store := NewRedis(client, nil)
 
@@ -149,6 +149,7 @@ func TestRedisInvalidate(t *testing.T) {
 
 	client := mocksStore.NewMockRedisClientInterface(ctrl)
 	client.EXPECT().Get("gocache_tag_tag1").Return(cacheKeys)
+	client.EXPECT().Del("gocache_tag_tag1").Return(&redis.IntCmd{})
 
 	store := NewRedis(client, nil)
 


### PR DESCRIPTION
I found during my end-to-end test using a real redis db that the redis client is returning strings, not bytes. The tag functionality was not working because of this.