### PR TITLE
feat: support ristretto TTL eviction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/allegro/bigcache v1.2.1
 	github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b
-	github.com/dgraph-io/ristretto v0.0.0-20191010170704-2ba187ef9534
+	github.com/dgraph-io/ristretto v0.0.2
 	github.com/go-redis/redis/v7 v7.2.0
 	github.com/golang/mock v1.4.3
 	github.com/prometheus/client_golang v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -12,6 +13,8 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b h1:L/QXpzIa3pOvUGt1D1lA5KjYhPBAN/3iWdP7xeFS9F0=
 github.com/bradfitz/gomemcache v0.0.0-20190913173617-a41fca850d0b/go.mod h1:H0wQNHz2YrLsuXOZozoeDmnHXkNCRmMW0gwFWDfEZDA=
+github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
+github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -19,6 +22,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/ristretto v0.0.0-20191010170704-2ba187ef9534 h1:9G6fVccQriMJu4nXwpwLDoy9y31t/KUSLAbPcoBgv+4=
 github.com/dgraph-io/ristretto v0.0.0-20191010170704-2ba187ef9534/go.mod h1:edzKIzGvqUCMzhTVWbiTSe75zD9Xxq0GtSBtFmaUTZs=
+github.com/dgraph-io/ristretto v0.0.2 h1:a5WaUrDa0qm0YrAAS1tUykT5El3kt62KNZZeMxQn3po=
+github.com/dgraph-io/ristretto v0.0.2/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -98,6 +103,7 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/store/ristretto.go
+++ b/store/ristretto.go
@@ -17,7 +17,7 @@ const (
 // RistrettoClientInterface represents a dgraph-io/ristretto client
 type RistrettoClientInterface interface {
 	Get(key interface{}) (interface{}, bool)
-	Set(key, value interface{}, cost int64) bool
+	SetWithTTL(key, value interface{}, cost int64, ttl time.Duration) bool
 	Del(key interface{})
 	Clear()
 }
@@ -60,7 +60,7 @@ func (s *RistrettoStore) Set(key interface{}, value interface{}, options *Option
 		options = s.options
 	}
 
-	if set := s.client.Set(key, value, options.CostValue()); !set {
+	if set := s.client.SetWithTTL(key, value, options.CostValue(), options.ExpirationValue()); !set {
 		err = fmt.Errorf("An error has occurred while setting value '%v' on key '%v'", value, key)
 	}
 

--- a/store/ristretto_test.go
+++ b/store/ristretto_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	mocksStore "github.com/eko/gocache/test/mocks/store/clients"
 	"github.com/golang/mock/gomock"
@@ -82,7 +83,7 @@ func TestRistrettoSet(t *testing.T) {
 	}
 
 	client := mocksStore.NewMockRistrettoClientInterface(ctrl)
-	client.EXPECT().Set(cacheKey, cacheValue, int64(4)).Return(true)
+	client.EXPECT().SetWithTTL(cacheKey, cacheValue, int64(4), 0*time.Second).Return(true)
 
 	store := NewRistretto(client, options)
 
@@ -107,7 +108,7 @@ func TestRistrettoSetWhenNoOptionsGiven(t *testing.T) {
 	}
 
 	client := mocksStore.NewMockRistrettoClientInterface(ctrl)
-	client.EXPECT().Set(cacheKey, cacheValue, int64(7)).Return(true)
+	client.EXPECT().SetWithTTL(cacheKey, cacheValue, int64(7), 0*time.Second).Return(true)
 
 	store := NewRistretto(client, options)
 
@@ -130,7 +131,7 @@ func TestRistrettoSetWhenError(t *testing.T) {
 	}
 
 	client := mocksStore.NewMockRistrettoClientInterface(ctrl)
-	client.EXPECT().Set(cacheKey, cacheValue, int64(7)).Return(false)
+	client.EXPECT().SetWithTTL(cacheKey, cacheValue, int64(7), 0*time.Second).Return(false)
 
 	store := NewRistretto(client, options)
 
@@ -150,9 +151,9 @@ func TestRistrettoSetWithTags(t *testing.T) {
 	cacheValue := []byte("my-cache-value")
 
 	client := mocksStore.NewMockRistrettoClientInterface(ctrl)
-	client.EXPECT().Set(cacheKey, cacheValue, int64(0)).Return(true)
+	client.EXPECT().SetWithTTL(cacheKey, cacheValue, int64(0), 0*time.Second).Return(true)
 	client.EXPECT().Get("gocache_tag_tag1").Return(nil, true)
-	client.EXPECT().Set("gocache_tag_tag1", []byte("my-key"), int64(0)).Return(true)
+	client.EXPECT().SetWithTTL("gocache_tag_tag1", []byte("my-key"), int64(0), 720*time.Hour).Return(true)
 
 	store := NewRistretto(client, nil)
 
@@ -172,9 +173,9 @@ func TestRistrettoSetWithTagsWhenAlreadyInserted(t *testing.T) {
 	cacheValue := []byte("my-cache-value")
 
 	client := mocksStore.NewMockRistrettoClientInterface(ctrl)
-	client.EXPECT().Set(cacheKey, cacheValue, int64(0)).Return(true)
+	client.EXPECT().SetWithTTL(cacheKey, cacheValue, int64(0), 0*time.Second).Return(true)
 	client.EXPECT().Get("gocache_tag_tag1").Return([]byte("my-key,a-second-key"), true)
-	client.EXPECT().Set("gocache_tag_tag1", []byte("my-key,a-second-key"), int64(0)).Return(true)
+	client.EXPECT().SetWithTTL("gocache_tag_tag1", []byte("my-key,a-second-key"), int64(0), 720*time.Hour).Return(true)
 
 	store := NewRistretto(client, nil)
 

--- a/test/mocks/store/clients/ristretto_interface.go
+++ b/test/mocks/store/clients/ristretto_interface.go
@@ -7,6 +7,7 @@ package mocks
 import (
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+	time "time"
 )
 
 // MockRistrettoClientInterface is a mock of RistrettoClientInterface interface
@@ -47,18 +48,18 @@ func (mr *MockRistrettoClientInterfaceMockRecorder) Get(key interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRistrettoClientInterface)(nil).Get), key)
 }
 
-// Set mocks base method
-func (m *MockRistrettoClientInterface) Set(key, value interface{}, cost int64) bool {
+// SetWithTTL mocks base method
+func (m *MockRistrettoClientInterface) SetWithTTL(key, value interface{}, cost int64, ttl time.Duration) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Set", key, value, cost)
+	ret := m.ctrl.Call(m, "SetWithTTL", key, value, cost, ttl)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// Set indicates an expected call of Set
-func (mr *MockRistrettoClientInterfaceMockRecorder) Set(key, value, cost interface{}) *gomock.Call {
+// SetWithTTL indicates an expected call of SetWithTTL
+func (mr *MockRistrettoClientInterfaceMockRecorder) SetWithTTL(key, value, cost, ttl interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockRistrettoClientInterface)(nil).Set), key, value, cost)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWithTTL", reflect.TypeOf((*MockRistrettoClientInterface)(nil).SetWithTTL), key, value, cost, ttl)
 }
 
 // Del mocks base method


### PR DESCRIPTION
In version v0.0.2 Sets with TTL functionality was added to ristretto. It would be very helpful to support it in gocache.