### PR TITLE
Implement GetWithTTL for Freecache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,4 @@ mocks:
 	mockgen -source=store/memcache.go -destination=test/mocks/store/clients/memcache_interface.go -package=mocks
 	mockgen -source=store/redis.go -destination=test/mocks/store/clients/redis_interface.go -package=mocks
 	mockgen -source=store/ristretto.go -destination=test/mocks/store/clients/ristretto_interface.go -package=mocks
+	mockgen -source=store/freecache.go -destination=test/mocks/store/clients/freecache_interface.go -package=mocks

--- a/cache/chain.go
+++ b/cache/chain.go
@@ -26,7 +26,7 @@ type ChainCache struct {
 	setChannel chan *chainKeyValue
 }
 
-// NewChain instanciates a new cache aggregator
+// NewChain instantiates a new cache aggregator
 func NewChain(caches ...SetterCacheInterface) *ChainCache {
 	chain := &ChainCache{
 		caches:     caches,
@@ -112,7 +112,7 @@ func (c *ChainCache) Clear() error {
 	return nil
 }
 
-// GetCaches returns all Chaind caches
+// GetCaches returns all Chained caches
 func (c *ChainCache) GetCaches() []SetterCacheInterface {
 	return c.caches
 }

--- a/store/freecache_test.go
+++ b/store/freecache_test.go
@@ -92,7 +92,78 @@ func TestFreecacheGetInvalidKey(t *testing.T) {
 
 	_, err := s.Get([]byte("key1"))
 	assert.Error(t, err, "key type not supported by Freecache store")
+}
 
+func TestFreecacheGetWithTTL(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cacheKey := "my-key"
+	cacheValue := []byte("my-cache-value")
+
+	client := mocksStore.NewMockFreecacheClientInterface(ctrl)
+	client.EXPECT().Get([]byte(cacheKey)).Return(cacheValue, nil)
+	client.EXPECT().TTL([]byte(cacheKey)).Return(uint32(5), nil)
+
+	options := &Options{Expiration: 3 * time.Second}
+	store := NewFreecache(client, options)
+
+	// When
+	value, ttl, err := store.GetWithTTL(cacheKey)
+
+	// Then
+	assert.Nil(t, err)
+	assert.Equal(t, cacheValue, value)
+	assert.Equal(t, 5*time.Second, ttl)
+}
+
+func TestFreecacheGetWithTTLWhenMissingItem(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cacheKey := "my-key"
+	expectedErr := errors.New("value not found in Freecache store")
+
+	client := mocksStore.NewMockFreecacheClientInterface(ctrl)
+	client.EXPECT().Get([]byte(cacheKey)).Return(nil, expectedErr)
+
+	options := &Options{Expiration: 3 * time.Second}
+	store := NewFreecache(client, options)
+
+	// When
+	value, ttl, err := store.GetWithTTL(cacheKey)
+
+	// Then
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, value)
+	assert.Equal(t, 0*time.Second, ttl)
+}
+
+func TestFreecacheGetWithTTLWhenErrorAtTTL(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cacheKey := "my-key"
+	cacheValue := []byte("my-cache-value")
+	expectedErr := errors.New("value not found in Freecache store")
+
+	client := mocksStore.NewMockFreecacheClientInterface(ctrl)
+	client.EXPECT().Get([]byte(cacheKey)).Return(cacheValue, nil)
+	client.EXPECT().TTL([]byte(cacheKey)).Return(uint32(0), expectedErr)
+
+	options := &Options{Expiration: 3 * time.Second}
+	store := NewFreecache(client, options)
+
+	// When
+	value, ttl, err := store.GetWithTTL(cacheKey)
+
+	// Then
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, value)
+	assert.Equal(t, 0*time.Second, ttl)
 }
 
 func TestFreecacheSet(t *testing.T) {

--- a/test/mocks/store/clients/freecache_interface.go
+++ b/test/mocks/store/clients/freecache_interface.go
@@ -62,6 +62,21 @@ func (mr *MockFreecacheClientInterfaceMockRecorder) GetInt(key interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInt", reflect.TypeOf((*MockFreecacheClientInterface)(nil).GetInt), key)
 }
 
+// TTL mocks base method
+func (m *MockFreecacheClientInterface) TTL(key []byte) (uint32, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TTL", key)
+	ret0, _ := ret[0].(uint32)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TTL indicates an expected call of TTL
+func (mr *MockFreecacheClientInterfaceMockRecorder) TTL(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TTL", reflect.TypeOf((*MockFreecacheClientInterface)(nil).TTL), key)
+}
+
 // Set mocks base method
 func (m *MockFreecacheClientInterface) Set(key, value []byte, expireSeconds int) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Freecache doesn't implement interface function GetWithTTL.
I assume that the person that added Freecache integration didn't pull the latest changes from master.