### PR TITLE
Do not hash key if its type is string

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -72,10 +72,16 @@ func (c *Cache) GetType() string {
 	return CacheType
 }
 
-// getCacheKey returns the cache key for the given key object by computing a
-// checksum of key struct
+// getCacheKey returns the cache key for the given key object by returning
+// the key if type is string or by computing a checksum of key structure
+// if its type is other than string
 func (c *Cache) getCacheKey(key interface{}) string {
-	return strings.ToLower(checksum(key))
+	switch key.(type) {
+	case string:
+		return strings.ToLower(key.(string))
+	default:
+		return strings.ToLower(checksum(key))
+	}
 }
 
 // checksum hashes a given object into a string

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -45,7 +45,7 @@ func TestCacheSet(t *testing.T) {
 	}
 
 	store := mocksStore.NewMockStoreInterface(ctrl)
-	store.EXPECT().Set("9b1ac8a6e8ca8ca9477c0a252eb37756", value, options).Return(nil)
+	store.EXPECT().Set("my-key", value, options).Return(nil)
 
 	cache := New(store)
 
@@ -72,7 +72,7 @@ func TestCacheSetWhenErrorOccurs(t *testing.T) {
 	storeErr := errors.New("An error has occurred while inserting data into store")
 
 	store := mocksStore.NewMockStoreInterface(ctrl)
-	store.EXPECT().Set("9b1ac8a6e8ca8ca9477c0a252eb37756", value, options).Return(storeErr)
+	store.EXPECT().Set("my-key", value, options).Return(storeErr)
 
 	cache := New(store)
 
@@ -93,7 +93,7 @@ func TestCacheGet(t *testing.T) {
 	}
 
 	store := mocksStore.NewMockStoreInterface(ctrl)
-	store.EXPECT().Get("9b1ac8a6e8ca8ca9477c0a252eb37756").Return(cacheValue, nil)
+	store.EXPECT().Get("my-key").Return(cacheValue, nil)
 
 	cache := New(store)
 
@@ -113,7 +113,7 @@ func TestCacheGetWhenNotFound(t *testing.T) {
 	returnedErr := errors.New("Unable to find item in store")
 
 	store := mocksStore.NewMockStoreInterface(ctrl)
-	store.EXPECT().Get("9b1ac8a6e8ca8ca9477c0a252eb37756").Return(nil, returnedErr)
+	store.EXPECT().Get("my-key").Return(nil, returnedErr)
 
 	cache := New(store)
 
@@ -138,7 +138,7 @@ func TestCacheGetWithTTL(t *testing.T) {
 	expiration := 1 * time.Second
 
 	store := mocksStore.NewMockStoreInterface(ctrl)
-	store.EXPECT().GetWithTTL("9b1ac8a6e8ca8ca9477c0a252eb37756").
+	store.EXPECT().GetWithTTL("my-key").
 		Return(cacheValue, expiration, nil)
 
 	cache := New(store)
@@ -161,7 +161,7 @@ func TestCacheGetWithTTLWhenNotFound(t *testing.T) {
 	expiration := 0 * time.Second
 
 	store := mocksStore.NewMockStoreInterface(ctrl)
-	store.EXPECT().GetWithTTL("9b1ac8a6e8ca8ca9477c0a252eb37756").
+	store.EXPECT().GetWithTTL("my-key").
 		Return(nil, expiration, returnedErr)
 
 	cache := New(store)
@@ -205,13 +205,51 @@ func TestCacheGetType(t *testing.T) {
 	assert.Equal(t, CacheType, cache.GetType())
 }
 
+func TestCacheGetCacheKeyWhenKeyIsString(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := mocksStore.NewMockStoreInterface(ctrl)
+
+	cache := New(store)
+
+	// When
+	computedKey := cache.getCacheKey("my-Key")
+
+	// Then
+	assert.Equal(t, "my-key", computedKey)
+}
+
+func TestCacheGetCacheKeyWhenKeyIsStruct(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	store := mocksStore.NewMockStoreInterface(ctrl)
+
+	cache := New(store)
+
+	// When
+	key := &struct {
+		Hello string
+	}{
+		Hello: "world",
+	}
+
+	computedKey := cache.getCacheKey(key)
+
+	// Then
+	assert.Equal(t, "8144fe5310cf0e62ac83fd79c113aad2", computedKey)
+}
+
 func TestCacheDelete(t *testing.T) {
 	// Given
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	store := mocksStore.NewMockStoreInterface(ctrl)
-	store.EXPECT().Delete("9b1ac8a6e8ca8ca9477c0a252eb37756").Return(nil)
+	store.EXPECT().Delete("my-key").Return(nil)
 
 	cache := New(store)
 
@@ -310,7 +348,7 @@ func TestCacheDeleteWhenError(t *testing.T) {
 	expectedErr := errors.New("Unable to delete key")
 
 	store := mocksStore.NewMockStoreInterface(ctrl)
-	store.EXPECT().Delete("9b1ac8a6e8ca8ca9477c0a252eb37756").Return(expectedErr)
+	store.EXPECT().Delete("my-key").Return(expectedErr)
 
 	cache := New(store)
 


### PR DESCRIPTION
For keys that already have string type, hashing could be skipped.
Reason to do so:
- integration tests will be easier to do mainly because the method that does the hashing is not public;
- some cache mechanism like Redis Pub/Sub need a pattern to listen for events;