### PR TITLE
remove-log: drop logging in two places

### DIFF
--- a/cache/chain.go
+++ b/cache/chain.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/eko/gocache/store"
@@ -65,8 +64,6 @@ func (c *ChainCache) Get(key interface{}) (interface{}, error) {
 			c.setChannel <- &chainKeyValue{key, object, ttl, &storeType}
 			return object, nil
 		}
-
-		log.Printf("Unable to retrieve item from cache with store '%s': %v\n", storeType, err)
 	}
 
 	return object, err

--- a/cache/loadable.go
+++ b/cache/loadable.go
@@ -1,8 +1,6 @@
 package cache
 
 import (
-	"log"
-
 	"github.com/eko/gocache/store"
 )
 
@@ -56,7 +54,6 @@ func (c *LoadableCache) Get(key interface{}) (interface{}, error) {
 	// Unable to find in cache, try to load it from load function
 	object, err = c.loadFunc(key)
 	if err != nil {
-		log.Printf("An error has occurred while trying to load item from load function: %v\n", err)
 		return object, err
 	}
 


### PR DESCRIPTION
- it didn't appear that logging is absolutely necessary because errors are returned
- this can be cumbersome if you use a structured logger
- libraries probably shouldn't write to stdout/stderr