### PR TITLE
fix: fallback from redis to bigcache will panic

### DIFF
--- a/marshaler/marshaler.go
+++ b/marshaler/marshaler.go
@@ -25,12 +25,11 @@ func (c *Marshaler) Get(key interface{}, returnObj interface{}) (interface{}, er
 		return nil, err
 	}
 
-	switch result.(type) {
+	switch v := result.(type) {
 	case []byte:
-		err = msgpack.Unmarshal(result.([]byte), returnObj)
-
+		err = msgpack.Unmarshal(v, returnObj)
 	case string:
-		err = msgpack.Unmarshal([]byte(result.(string)), returnObj)
+		err = msgpack.Unmarshal([]byte(v), returnObj)
 	}
 
 	if err != nil {

--- a/store/bigcache.go
+++ b/store/bigcache.go
@@ -72,8 +72,7 @@ func (s *BigcacheStore) Set(key interface{}, value interface{}, options *Options
 	case []byte:
 		val = v
 	default:
-		// this convert may cause panic
-		val = value.([]byte)
+		return errors.New("value type not supported by Bigcache store")
 	}
 
 	err := s.client.Set(key.(string), val)

--- a/store/bigcache_test.go
+++ b/store/bigcache_test.go
@@ -136,6 +136,30 @@ func TestBigcacheSet(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestBigcacheSetString(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cacheKey := "my-key"
+
+	// The value is string when failback from Redis
+	cacheValue := "my-cache-value"
+
+	options := &Options{}
+
+	client := mocksStore.NewMockBigcacheClientInterface(ctrl)
+	client.EXPECT().Set(cacheKey, []byte(cacheValue)).Return(nil)
+
+	store := NewBigcache(client, nil)
+
+	// When
+	err := store.Set(cacheKey, cacheValue, options)
+
+	// Then
+	assert.Nil(t, err)
+}
+
 func TestBigcacheSetWhenError(t *testing.T) {
 	// Given
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
When faillback from Redis to Bigcache:  type of the value from Redis is string, set to Bigcache will cause panic, see #70.
According to the code from [marshaler](https://github.com/eko/gocache/blob/master/marshaler/marshaler.go#L28-L34), I made the same change to Bigcache store.