### PR TITLE
docs(readme): add descriptions about how to deal with the returned error from the redis storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,15 @@ if err != nil {
     panic(err)
 }
 
-value := cacheManager.Get("my-key")
+value, err := cacheManager.Get("my-key")
+switch err {
+	case nil:
+		fmt.Printf("Get the key '%s' from the redis cache. Result: %s", "my-key", value)
+	case redis.Nil:
+		fmt.Printf("Failed to find the key '%s' from the redis cache.", "my-key")
+	default:
+	    fmt.Printf("Failed to get the value from the redis cache with key '%s': %v", "my-key", err)
+}
 ```
 
 #### Freecache


### PR DESCRIPTION
Hi there. `gocache` is a really handy library. But when I used it with the redis storage for the first time, it took me a while to figure out how to deal with the case when the key does not exist. I think it may be better to add some examples to the README, and here it is.