### PR TITLE
fix: fix cacheManager use error with redis and pegasus

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ freecacheStore := store.NewFreecache(freecache.NewCache(1000), &Options{
 cacheManager := cache.New(freecacheStore)
 err := cacheManager.Set("by-key", []byte("my-value"), opts)
 if err != nil {
-	panic(err)
+    panic(err)
 }
 
 value := cacheManager.Get("my-key")
@@ -152,17 +152,17 @@ pegasusStore, err := store.NewPegasus(&store.OptionsPegasus{
     MetaServers: []string{"127.0.0.1:34601", "127.0.0.1:34602", "127.0.0.1:34603"},
 })
 
-if err != nil{
+if err != nil {
     fmt.Println(err)
     return
 }
 
 cacheManager := cache.New(pegasusStore)
-err = cacheManager.Set("my-key", "my-value"), store.Options{
+    err = cacheManager.Set("my-key", "my-value", &store.Options{
     Expiration: 10 * time.Second,
 })
 if err != nil {
-panic(err)
+    panic(err)
 }
 
 value, _ := cacheManager.Get("my-key")

--- a/store/bigcache.go
+++ b/store/bigcache.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	time "time"
+	"time"
 )
 
 // BigcacheClientInterface represents a allegro/bigcache client

--- a/store/bigcache_bench_test.go
+++ b/store/bigcache_bench_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
-	time "time"
+	"time"
 
 	"github.com/allegro/bigcache/v2"
 )

--- a/store/go_cache.go
+++ b/store/go_cache.go
@@ -3,7 +3,7 @@ package store
 import (
 	"errors"
 	"fmt"
-	time "time"
+	"time"
 )
 
 const (

--- a/store/interface.go
+++ b/store/interface.go
@@ -3,6 +3,7 @@ package store
 import (
 	"time"
 )
+
 // StoreInterface is the interface for all available stores
 type StoreInterface interface {
 	Get(key interface{}) (interface{}, error)

--- a/store/memcache.go
+++ b/store/memcache.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	time "time"
+	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
 )

--- a/store/memcache_bench_test.go
+++ b/store/memcache_bench_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math"
 	"testing"
-	time "time"
+	"time"
 
 	"github.com/bradfitz/gomemcache/memcache"
 )

--- a/store/options.go
+++ b/store/options.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"time"
 )
 
@@ -15,6 +16,9 @@ type Options struct {
 
 	// Tags allows to specify associated tags to the current value
 	Tags []string
+
+	// Ctx pass context for control timeout for all operations
+	Ctx context.Context
 }
 
 // CostValue returns the allocated memory capacity
@@ -30,4 +34,9 @@ func (o Options) ExpirationValue() time.Duration {
 // TagsValue returns the tags option value
 func (o Options) TagsValue() []string {
 	return o.Tags
+}
+
+// CtxValue returns the ctx option value
+func (o Options) CtxValue() context.Context {
+	return o.Ctx
 }

--- a/store/options_test.go
+++ b/store/options_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -35,4 +36,14 @@ func TestOptionsTagsValue(t *testing.T) {
 
 	// When - Then
 	assert.Equal(t, []string{"tag1", "tag2", "tag3"}, options.TagsValue())
+}
+
+func TestOptions_CtxValue(t *testing.T) {
+	// Given
+	options := Options{
+		Ctx: context.Background(),
+	}
+
+	// When - Then
+	assert.Equal(t, context.Background(), options.Ctx)
 }

--- a/store/pegasus.go
+++ b/store/pegasus.go
@@ -47,19 +47,19 @@ type PegasusStore struct {
 }
 
 // NewPegasus creates a new store to pegasus instance(s)
-func NewPegasus(ctx context.Context, options *OptionsPegasus) (*PegasusStore, error) {
+func NewPegasus(options *OptionsPegasus) (*PegasusStore, error) {
 	if options == nil {
 		options = &OptionsPegasus{}
 	}
 
-	if err := createTable(ctx, options); err != nil {
+	if err := createTable(options); err != nil {
 		return nil, err
 	}
 
 	client := pegasus.NewClient(pegasus.Config{
 		MetaServers: options.MetaServers,
 	})
-	table, err := client.OpenTable(ctx, options.TableName)
+	table, err := client.OpenTable(options.Ctx, options.TableName)
 	defer table.Close()
 	if err != nil {
 		return nil, err
@@ -85,18 +85,21 @@ func validateOptions(options *OptionsPegasus) error {
 	if options.TableScanNum < 1 {
 		options.TableScanNum = DefaultScanNum
 	}
+	if options.Ctx == nil {
+		options.Ctx = context.Background()
+	}
 
 	return nil
 }
 
 // createTable for create table by options
-func createTable(ctx context.Context, options *OptionsPegasus) error {
+func createTable(options *OptionsPegasus) error {
 	if err := validateOptions(options); err != nil {
 		return err
 	}
 
 	tableClient := admin.NewClient(admin.Config{MetaServers: options.MetaServers})
-	tableList, err := tableClient.ListTables(ctx)
+	tableList, err := tableClient.ListTables(options.Ctx)
 	if err != nil {
 		return err
 	}
@@ -108,13 +111,17 @@ func createTable(ctx context.Context, options *OptionsPegasus) error {
 	}
 
 	// if not found then create table of options
-	return tableClient.CreateTable(ctx, options.TableName, options.TablePartitionNum)
+	return tableClient.CreateTable(options.Ctx, options.TableName, options.TablePartitionNum)
 }
 
 // dropTable for drop table
-func dropTable(ctx context.Context, options *OptionsPegasus) error {
+func dropTable(options *OptionsPegasus) error {
+	if err := validateOptions(options); err != nil {
+		return err
+	}
+
 	tableClient := admin.NewClient(admin.Config{MetaServers: options.MetaServers})
-	return tableClient.DropTable(ctx, options.TableName)
+	return tableClient.DropTable(options.Ctx, options.TableName)
 }
 
 // Close when exit store
@@ -123,14 +130,14 @@ func (p *PegasusStore) Close() error {
 }
 
 // Get returns data stored from a given key
-func (p *PegasusStore) Get(ctx context.Context, key interface{}) (interface{}, error) {
-	table, err := p.client.OpenTable(ctx, p.options.TableName)
+func (p *PegasusStore) Get(key interface{}) (interface{}, error) {
+	table, err := p.client.OpenTable(p.options.Ctx, p.options.TableName)
 	defer table.Close()
 	if err != nil {
 		return nil, err
 	}
 
-	value, err := table.Get(ctx, []byte(cast.ToString(key)), empty)
+	value, err := table.Get(p.options.Ctx, []byte(cast.ToString(key)), empty)
 	if err != nil {
 		return nil, err
 	}
@@ -139,19 +146,19 @@ func (p *PegasusStore) Get(ctx context.Context, key interface{}) (interface{}, e
 }
 
 // GetWithTTL returns data stored from a given key and its corresponding TTL
-func (p *PegasusStore) GetWithTTL(ctx context.Context, key interface{}) (interface{}, time.Duration, error) {
-	table, err := p.client.OpenTable(ctx, p.options.TableName)
+func (p *PegasusStore) GetWithTTL(key interface{}) (interface{}, time.Duration, error) {
+	table, err := p.client.OpenTable(p.options.Ctx, p.options.TableName)
 	defer table.Close()
 	if err != nil {
 		return nil, 0, err
 	}
 
-	value, err := table.Get(ctx, []byte(cast.ToString(key)), empty)
+	value, err := table.Get(p.options.Ctx, []byte(cast.ToString(key)), empty)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	ttl, err := table.TTL(ctx, []byte(cast.ToString(key)), empty)
+	ttl, err := table.TTL(p.options.Ctx, []byte(cast.ToString(key)), empty)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -160,36 +167,39 @@ func (p *PegasusStore) GetWithTTL(ctx context.Context, key interface{}) (interfa
 }
 
 // Set defines data in Pegasus for given key identifier
-func (p *PegasusStore) Set(ctx context.Context, key, value interface{}, options *Options) error {
+func (p *PegasusStore) Set(key, value interface{}, options *Options) error {
 	if options == nil {
 		options = &Options{}
 	}
+	if options.Ctx == nil {
+		options.Ctx = context.Background()
+	}
 
-	table, err := p.client.OpenTable(ctx, p.options.TableName)
+	table, err := p.client.OpenTable(options.Ctx, p.options.TableName)
 	defer table.Close()
 	if err != nil {
 		return err
 	}
 
-	err = table.SetTTL(ctx, []byte(cast.ToString(key)), empty, []byte(cast.ToString(value)), options.Expiration)
+	err = table.SetTTL(options.Ctx, []byte(cast.ToString(key)), empty, []byte(cast.ToString(value)), options.Expiration)
 	if err != nil {
 		return err
 	}
 
 	if tags := options.TagsValue(); len(tags) > 0 {
-		if err = p.setTags(ctx, key, tags); err != nil {
+		if err = p.setTags(key, tags); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (p *PegasusStore) setTags(ctx context.Context, key interface{}, tags []string) error {
+func (p *PegasusStore) setTags(key interface{}, tags []string) error {
 	for _, tag := range tags {
 		var tagKey = fmt.Sprintf(PegasusTagPattern, tag)
 		var cacheKeys = []string{}
 
-		if result, err := p.Get(ctx, tagKey); err == nil {
+		if result, err := p.Get(tagKey); err == nil {
 			if bytes, ok := result.([]byte); ok {
 				cacheKeys = strings.Split(string(bytes), ",")
 			}
@@ -207,7 +217,7 @@ func (p *PegasusStore) setTags(ctx context.Context, key interface{}, tags []stri
 			cacheKeys = append(cacheKeys, key.(string))
 		}
 
-		if err := p.Set(ctx, tagKey, []byte(strings.Join(cacheKeys, ",")), &Options{
+		if err := p.Set(tagKey, []byte(strings.Join(cacheKeys, ",")), &Options{
 			Expiration: 720 * time.Hour,
 		}); err != nil {
 			return err
@@ -218,22 +228,22 @@ func (p *PegasusStore) setTags(ctx context.Context, key interface{}, tags []stri
 }
 
 // Delete removes data from Pegasus for given key identifier
-func (p *PegasusStore) Delete(ctx context.Context, key interface{}) error {
-	table, err := p.client.OpenTable(ctx, p.options.TableName)
+func (p *PegasusStore) Delete(key interface{}) error {
+	table, err := p.client.OpenTable(p.options.Ctx, p.options.TableName)
 	defer table.Close()
 	if err != nil {
 		return err
 	}
 
-	return table.Del(ctx, []byte(cast.ToString(key)), empty)
+	return table.Del(p.options.Ctx, []byte(cast.ToString(key)), empty)
 }
 
 // Invalidate invalidates some cache data in Pegasus for given options
-func (p *PegasusStore) Invalidate(ctx context.Context, options InvalidateOptions) error {
+func (p *PegasusStore) Invalidate(options InvalidateOptions) error {
 	if tags := options.TagsValue(); len(tags) > 0 {
 		for _, tag := range tags {
 			var tagKey = fmt.Sprintf(PegasusTagPattern, tag)
-			result, err := p.Get(ctx, tagKey)
+			result, err := p.Get(tagKey)
 			if err != nil {
 				return nil
 			}
@@ -244,7 +254,7 @@ func (p *PegasusStore) Invalidate(ctx context.Context, options InvalidateOptions
 			}
 
 			for _, cacheKey := range cacheKeys {
-				if err := p.Delete(ctx, cacheKey); err != nil {
+				if err := p.Delete(cacheKey); err != nil {
 					return err
 				}
 			}
@@ -255,15 +265,15 @@ func (p *PegasusStore) Invalidate(ctx context.Context, options InvalidateOptions
 }
 
 // Clear resets all data in the store
-func (p *PegasusStore) Clear(ctx context.Context) error {
-	table, err := p.client.OpenTable(ctx, p.options.TableName)
+func (p *PegasusStore) Clear() error {
+	table, err := p.client.OpenTable(p.options.Ctx, p.options.TableName)
 	defer table.Close()
 	if err != nil {
 		return err
 	}
 
 	// init full scan
-	scanners, err := table.GetUnorderedScanners(ctx, p.options.TablePartitionNum, &pegasus.ScannerOptions{
+	scanners, err := table.GetUnorderedScanners(p.options.Ctx, p.options.TablePartitionNum, &pegasus.ScannerOptions{
 		BatchSize: p.options.TableScanNum,
 		// Values can be optimized out during scanning to reduce the workload.
 		NoValue: true,
@@ -276,14 +286,14 @@ func (p *PegasusStore) Clear(ctx context.Context) error {
 	for _, scanner := range scanners {
 		// Iterates sequentially.
 		for true {
-			completed, hashKey, _, _, err := scanner.Next(ctx)
+			completed, hashKey, _, _, err := scanner.Next(p.options.Ctx)
 			if err != nil {
 				return err
 			}
 			if completed {
 				break
 			}
-			err = p.Delete(ctx, hashKey)
+			err = p.Delete(hashKey)
 			if err != nil {
 				return err
 			}

--- a/store/pegasus_bench_test.go
+++ b/store/pegasus_bench_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"context"
 	"fmt"
 	"math"
 
@@ -10,7 +9,7 @@ import (
 
 // run go test -bench='BenchmarkPegasusStore*' -benchtime=1s -count=1 -run=none
 func BenchmarkPegasusStore_Set(b *testing.B) {
-	p, _ := NewPegasus(context.Background(),testPegasusOptions())
+	p, _ := NewPegasus(testPegasusOptions())
 	defer p.Close()
 
 	for k := 0.; k <= 10; k++ {
@@ -20,7 +19,7 @@ func BenchmarkPegasusStore_Set(b *testing.B) {
 				key := fmt.Sprintf("test-%d", n)
 				value := []byte(fmt.Sprintf("value-%d", n))
 
-				p.Set(context.Background(),key, value, &Options{
+				p.Set(key, value, &Options{
 					Tags: []string{fmt.Sprintf("tag-%d", n)},
 				})
 			}
@@ -29,19 +28,19 @@ func BenchmarkPegasusStore_Set(b *testing.B) {
 }
 
 func BenchmarkPegasusStore_Get(b *testing.B) {
-	p, _ := NewPegasus(context.Background(),testPegasusOptions())
+	p, _ := NewPegasus(testPegasusOptions())
 	defer p.Close()
 
 	key := "test"
 	value := []byte("value")
 
-	p.Set(context.Background(),key, value, nil)
+	p.Set(key, value, nil)
 
 	for k := 0.; k <= 10; k++ {
 		n := int(math.Pow(2, k))
 		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
 			for i := 0; i < b.N*n; i++ {
-				_, _ = p.Get(context.Background(),key)
+				_, _ = p.Get(key)
 			}
 		})
 	}

--- a/store/pegasus_test.go
+++ b/store/pegasus_test.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"context"
 	"github.com/smartystreets/assertions/should"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/spf13/cast"
@@ -9,7 +8,7 @@ import (
 	"time"
 )
 
-// run go test -v -run='TestPegasus*'
+// run go test -run='TestPegasus*' -race -cover -coverprofile=coverage.txt -covermode=atomic -v ./...
 // install local pegasus onebox reference https://pegasus.apache.org/en/docs/build/compile-from-source/
 func testPegasusOptions() *OptionsPegasus {
 	return &OptionsPegasus{
@@ -27,7 +26,7 @@ func TestNewPegasus(t *testing.T) {
 	Convey("Pegasus TestNewPegasus should return client and nil error", t, func() {
 		skipPegasusTest(t)
 
-		p, err := NewPegasus(context.Background(), testPegasusOptions())
+		p, err := NewPegasus(testPegasusOptions())
 		defer p.Close()
 		So(err, ShouldBeNil)
 	})
@@ -48,7 +47,7 @@ func Test_createTable(t *testing.T) {
 	Convey("Pegasus Test createTable should return nil", t, func() {
 		skipPegasusTest(t)
 
-		err := createTable(context.Background(), testPegasusOptions())
+		err := createTable(testPegasusOptions())
 		So(err, ShouldBeNil)
 	})
 }
@@ -57,7 +56,7 @@ func Test_dropTable(t *testing.T) {
 	Convey("Pegasus Test dropTable should return nil", t, func() {
 		skipPegasusTest(t)
 
-		err := dropTable(context.Background(), testPegasusOptions())
+		err := dropTable(testPegasusOptions())
 		So(err, ShouldBeNil)
 	})
 }
@@ -66,7 +65,7 @@ func TestPegasusStore_Close(t *testing.T) {
 	Convey("Pegasus TestClose for pegasus store", t, func() {
 		skipPegasusTest(t)
 
-		p, _ := NewPegasus(context.Background(), testPegasusOptions())
+		p, _ := NewPegasus(testPegasusOptions())
 		So(p.Close(), ShouldBeNil)
 	})
 }
@@ -75,12 +74,12 @@ func TestPegasusStore_Get(t *testing.T) {
 	Convey("Pegasus TestGet for pegasus store", t, func() {
 		skipPegasusTest(t)
 
-		p, _ := NewPegasus(context.Background(), testPegasusOptions())
+		p, _ := NewPegasus(testPegasusOptions())
 		defer p.Close()
 
 		k, v := "test-gocache-key", "test-gocache-value"
-		p.Set(context.Background(), k, v, &Options{})
-		value, err := p.Get(context.Background(), k)
+		p.Set(k, v, &Options{})
+		value, err := p.Get(k)
 		So(cast.ToString(value), ShouldEqual, v)
 		So(err, ShouldBeNil)
 	})
@@ -90,33 +89,33 @@ func TestPegasusStore_GetWithTTL(t *testing.T) {
 	Convey("Pegasus TestGetWithTTL for pegasus store", t, func() {
 		skipPegasusTest(t)
 
-		p, _ := NewPegasus(context.Background(), testPegasusOptions())
+		p, _ := NewPegasus(testPegasusOptions())
 		defer p.Close()
 
 		Convey("test set ttl that not achieve", func() {
 			k, v, retention := "test-gocache-key-01", "test-gocache-value", time.Minute*10
-			p.Set(context.Background(), k, v, &Options{Expiration: retention})
+			p.Set(k, v, &Options{Expiration: retention})
 
-			value, ttl, err := p.GetWithTTL(context.Background(), k)
+			value, ttl, err := p.GetWithTTL(k)
 			So(cast.ToString(value), ShouldEqual, v)
 			So(ttl, should.BeLessThanOrEqualTo, retention)
 			So(err, ShouldBeNil)
 		})
 		Convey("test no ttl", func() {
 			k, v := "test-gocache-key-02", "test-gocache-value"
-			p.Set(context.Background(), k, v, &Options{})
+			p.Set(k, v, &Options{})
 
-			value, ttl, err := p.GetWithTTL(context.Background(), k)
+			value, ttl, err := p.GetWithTTL(k)
 			So(cast.ToString(value), ShouldEqual, v)
 			So(ttl, should.BeLessThanOrEqualTo, PegasusNOTTL)
 			So(err, ShouldBeNil)
 		})
 		Convey("test set ttl that already achieve", func() {
 			k, v, retention := "test-gocache-key-03", "test-gocache-value", time.Millisecond*10
-			p.Set(context.Background(), k, v, &Options{Expiration: retention})
+			p.Set(k, v, &Options{Expiration: retention})
 			time.Sleep(time.Second * 1)
 
-			value, ttl, err := p.GetWithTTL(context.Background(), k)
+			value, ttl, err := p.GetWithTTL(k)
 			So(cast.ToString(value), ShouldBeEmpty)
 			So(ttl, should.BeLessThanOrEqualTo, PegasusNOENTRY)
 			So(err, ShouldBeNil)
@@ -128,11 +127,11 @@ func TestPegasusStore_Set(t *testing.T) {
 	Convey("Pegasus TestSet for pegasus store", t, func() {
 		skipPegasusTest(t)
 
-		p, _ := NewPegasus(context.Background(), testPegasusOptions())
+		p, _ := NewPegasus(testPegasusOptions())
 		defer p.Close()
 
 		k, v := "test-gocache-key", "test-gocache-value"
-		err := p.Set(context.Background(), k, v, &Options{})
+		err := p.Set(k, v, &Options{})
 		So(err, ShouldBeNil)
 	})
 }
@@ -141,11 +140,11 @@ func TestPegasusStore_setTags(t *testing.T) {
 	Convey("Pegasus Test set tags for pegasus store", t, func() {
 		skipPegasusTest(t)
 
-		p, _ := NewPegasus(context.Background(), testPegasusOptions())
+		p, _ := NewPegasus(testPegasusOptions())
 		defer p.Close()
 
 		k, tags := "test-gocache-tags-key", []string{"test01", "test02"}
-		err := p.setTags(context.Background(), k, tags)
+		err := p.setTags(k, tags)
 		So(err, ShouldBeNil)
 	})
 }
@@ -154,13 +153,13 @@ func TestPegasusStore_Delete(t *testing.T) {
 	Convey("Pegasus TestDelete for pegasus store", t, func() {
 		skipPegasusTest(t)
 
-		p, _ := NewPegasus(context.Background(), testPegasusOptions())
+		p, _ := NewPegasus(testPegasusOptions())
 		defer p.Close()
 
 		k, v := "test-gocache-key", "test-gocache-value"
-		p.Set(context.Background(), k, v, &Options{})
+		p.Set(k, v, &Options{})
 
-		err := p.Delete(context.Background(), k)
+		err := p.Delete(k)
 		So(err, ShouldBeNil)
 	})
 }
@@ -169,10 +168,10 @@ func TestPegasusStore_Invalidate(t *testing.T) {
 	Convey("Pegasus TestInvalidate for pegasus store", t, func() {
 		skipPegasusTest(t)
 
-		p, _ := NewPegasus(context.Background(), testPegasusOptions())
+		p, _ := NewPegasus(testPegasusOptions())
 		defer p.Close()
 
-		err := p.Invalidate(context.Background(), InvalidateOptions{})
+		err := p.Invalidate(InvalidateOptions{})
 		So(err, ShouldBeNil)
 	})
 }
@@ -181,15 +180,15 @@ func TestPegasusStore_Clear(t *testing.T) {
 	Convey("Pegasus TestClear for pegasus store", t, func() {
 		skipPegasusTest(t)
 
-		p, _ := NewPegasus(context.Background(), testPegasusOptions())
+		p, _ := NewPegasus(testPegasusOptions())
 		defer p.Close()
 
 		k1, v1 := "test-gocache-key-01", "test-gocache-value"
 		k2, v2 := "test-gocache-key-01", "test-gocache-value"
-		p.Set(context.Background(), k1, v1, &Options{})
-		p.Set(context.Background(), k2, v2, &Options{})
+		p.Set(k1, v1, &Options{})
+		p.Set(k2, v2, &Options{})
 
-		err := p.Clear(context.Background())
+		err := p.Clear()
 		So(err, ShouldBeNil)
 	})
 }

--- a/store/redis_bench_test.go
+++ b/store/redis_bench_test.go
@@ -1,12 +1,11 @@
 package store
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"testing"
 
-	redis "github.com/go-redis/redis/v8"
+	"github.com/go-redis/redis/v8"
 )
 
 func BenchmarkRedisSet(b *testing.B) {
@@ -21,7 +20,7 @@ func BenchmarkRedisSet(b *testing.B) {
 				key := fmt.Sprintf("test-%d", n)
 				value := []byte(fmt.Sprintf("value-%d", n))
 
-				store.Set(context.TODO(), key, value, &Options{
+				store.Set(key, value, &Options{
 					Tags: []string{fmt.Sprintf("tag-%d", n)},
 				})
 			}
@@ -37,13 +36,13 @@ func BenchmarkRedisGet(b *testing.B) {
 	key := "test"
 	value := []byte("value")
 
-	store.Set(context.TODO(), key, value, nil)
+	store.Set(key, value, nil)
 
 	for k := 0.; k <= 10; k++ {
 		n := int(math.Pow(2, k))
 		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
 			for i := 0; i < b.N*n; i++ {
-				_, _ = store.Get(context.TODO(), key)
+				_, _ = store.Get(key)
 			}
 		})
 	}

--- a/store/redis_test.go
+++ b/store/redis_test.go
@@ -36,12 +36,12 @@ func TestRedisGet(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := mocksStore.NewMockRedisClientInterface(ctrl)
-	client.EXPECT().Get(context.TODO(), "my-key").Return(&redis.StringCmd{})
+	client.EXPECT().Get(context.Background(), "my-key").Return(&redis.StringCmd{})
 
 	store := NewRedis(client, nil)
 
 	// When
-	value, err := store.Get(context.TODO(), "my-key")
+	value, err := store.Get("my-key")
 
 	// Then
 	assert.Nil(t, err)
@@ -60,12 +60,12 @@ func TestRedisSet(t *testing.T) {
 	}
 
 	client := mocksStore.NewMockRedisClientInterface(ctrl)
-	client.EXPECT().Set(context.TODO(), "my-key", cacheValue, 5*time.Second).Return(&redis.StatusCmd{})
+	client.EXPECT().Set(context.Background(), "my-key", cacheValue, 5*time.Second).Return(&redis.StatusCmd{})
 
 	store := NewRedis(client, options)
 
 	// When
-	err := store.Set(context.TODO(), cacheKey, cacheValue, &Options{
+	err := store.Set(cacheKey, cacheValue, &Options{
 		Expiration: 5 * time.Second,
 	})
 
@@ -85,12 +85,12 @@ func TestRedisSetWhenNoOptionsGiven(t *testing.T) {
 	}
 
 	client := mocksStore.NewMockRedisClientInterface(ctrl)
-	client.EXPECT().Set(context.TODO(), "my-key", cacheValue, 6*time.Second).Return(&redis.StatusCmd{})
+	client.EXPECT().Set(context.Background(), "my-key", cacheValue, 6*time.Second).Return(&redis.StatusCmd{})
 
 	store := NewRedis(client, options)
 
 	// When
-	err := store.Set(context.TODO(), cacheKey, cacheValue, nil)
+	err := store.Set(cacheKey, cacheValue, nil)
 
 	// Then
 	assert.Nil(t, err)
@@ -105,14 +105,14 @@ func TestRedisSetWithTags(t *testing.T) {
 	cacheValue := "my-cache-value"
 
 	client := mocksStore.NewMockRedisClientInterface(ctrl)
-	client.EXPECT().Set(context.TODO(), cacheKey, cacheValue, time.Duration(0)).Return(&redis.StatusCmd{})
-	client.EXPECT().SAdd(context.TODO(), "gocache_tag_tag1", "my-key").Return(&redis.IntCmd{})
-	client.EXPECT().Expire(context.TODO(), "gocache_tag_tag1", 720*time.Hour).Return(&redis.BoolCmd{})
+	client.EXPECT().Set(context.Background(), cacheKey, cacheValue, time.Duration(0)).Return(&redis.StatusCmd{})
+	client.EXPECT().SAdd(context.Background(), "gocache_tag_tag1", "my-key").Return(&redis.IntCmd{})
+	client.EXPECT().Expire(context.Background(), "gocache_tag_tag1", 720*time.Hour).Return(&redis.BoolCmd{})
 
 	store := NewRedis(client, nil)
 
 	// When
-	err := store.Set(context.TODO(), cacheKey, cacheValue, &Options{Tags: []string{"tag1"}})
+	err := store.Set(cacheKey, cacheValue, &Options{Tags: []string{"tag1"}})
 
 	// Then
 	assert.Nil(t, err)
@@ -126,12 +126,12 @@ func TestRedisDelete(t *testing.T) {
 	cacheKey := "my-key"
 
 	client := mocksStore.NewMockRedisClientInterface(ctrl)
-	client.EXPECT().Del(context.TODO(), "my-key").Return(&redis.IntCmd{})
+	client.EXPECT().Del(context.Background(), "my-key").Return(&redis.IntCmd{})
 
 	store := NewRedis(client, nil)
 
 	// When
-	err := store.Delete(context.TODO(), cacheKey)
+	err := store.Delete(cacheKey)
 
 	// Then
 	assert.Nil(t, err)
@@ -149,13 +149,13 @@ func TestRedisInvalidate(t *testing.T) {
 	cacheKeys := &redis.StringSliceCmd{}
 
 	client := mocksStore.NewMockRedisClientInterface(ctrl)
-	client.EXPECT().SMembers(context.TODO(), "gocache_tag_tag1").Return(cacheKeys)
-	client.EXPECT().Del(context.TODO(), "gocache_tag_tag1").Return(&redis.IntCmd{})
+	client.EXPECT().SMembers(context.Background(), "gocache_tag_tag1").Return(cacheKeys)
+	client.EXPECT().Del(context.Background(), "gocache_tag_tag1").Return(&redis.IntCmd{})
 
 	store := NewRedis(client, nil)
 
 	// When
-	err := store.Invalidate(context.TODO(), options)
+	err := store.Invalidate(options)
 
 	// Then
 	assert.Nil(t, err)
@@ -167,12 +167,12 @@ func TestRedisClear(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := mocksStore.NewMockRedisClientInterface(ctrl)
-	client.EXPECT().FlushAll(context.TODO()).Return(&redis.StatusCmd{})
+	client.EXPECT().FlushAll(context.Background()).Return(&redis.StatusCmd{})
 
 	store := NewRedis(client, nil)
 
 	// When
-	err := store.Clear(context.TODO())
+	err := store.Clear()
 
 	// Then
 	assert.Nil(t, err)

--- a/store/rediscluster_bench_test.go
+++ b/store/rediscluster_bench_test.go
@@ -1,13 +1,12 @@
 package store
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"strings"
 	"testing"
 
-	redis "github.com/go-redis/redis/v8"
+	"github.com/go-redis/redis/v8"
 )
 
 // should be configured to connect to real Redis Cluster
@@ -24,7 +23,7 @@ func BenchmarkRedisClusterSet(b *testing.B) {
 				key := fmt.Sprintf("test-%d", n)
 				value := []byte(fmt.Sprintf("value-%d", n))
 
-				store.Set(context.TODO(), key, value, &Options{
+				store.Set(key, value, &Options{
 					Tags: []string{fmt.Sprintf("tag-%d", n)},
 				})
 			}
@@ -41,13 +40,13 @@ func BenchmarkRedisClusterGet(b *testing.B) {
 	key := "test"
 	value := []byte("value")
 
-	store.Set(context.TODO(), key, value, nil)
+	store.Set(key, value, nil)
 
 	for k := 0.; k <= 10; k++ {
 		n := int(math.Pow(2, k))
 		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
 			for i := 0; i < b.N*n; i++ {
-				_, _ = store.Get(context.TODO(), key)
+				_, _ = store.Get(key)
 			}
 		})
 	}

--- a/store/rediscluster_test.go
+++ b/store/rediscluster_test.go
@@ -36,12 +36,12 @@ func TestRedisClusterGet(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := mocksStore.NewMockRedisClusterClientInterface(ctrl)
-	client.EXPECT().Get(context.TODO(), "my-key").Return(&redis.StringCmd{})
+	client.EXPECT().Get(context.Background(), "my-key").Return(&redis.StringCmd{})
 
 	store := NewRedisCluster(client, nil)
 
 	// When
-	value, err := store.Get(context.TODO(), "my-key")
+	value, err := store.Get("my-key")
 
 	// Then
 	assert.Nil(t, err)
@@ -60,12 +60,12 @@ func TestRedisClusterSet(t *testing.T) {
 	}
 
 	client := mocksStore.NewMockRedisClusterClientInterface(ctrl)
-	client.EXPECT().Set(context.TODO(), "my-key", cacheValue, 5*time.Second).Return(&redis.StatusCmd{})
+	client.EXPECT().Set(context.Background(), "my-key", cacheValue, 5*time.Second).Return(&redis.StatusCmd{})
 
 	store := NewRedisCluster(client, options)
 
 	// When
-	err := store.Set(context.TODO(), cacheKey, cacheValue, &Options{
+	err := store.Set(cacheKey, cacheValue, &Options{
 		Expiration: 5 * time.Second,
 	})
 
@@ -85,12 +85,12 @@ func TestRedisClusterSetWhenNoOptionsGiven(t *testing.T) {
 	}
 
 	client := mocksStore.NewMockRedisClusterClientInterface(ctrl)
-	client.EXPECT().Set(context.TODO(), "my-key", cacheValue, 6*time.Second).Return(&redis.StatusCmd{})
+	client.EXPECT().Set(context.Background(), "my-key", cacheValue, 6*time.Second).Return(&redis.StatusCmd{})
 
 	store := NewRedisCluster(client, options)
 
 	// When
-	err := store.Set(context.TODO(), cacheKey, cacheValue, nil)
+	err := store.Set(cacheKey, cacheValue, nil)
 
 	// Then
 	assert.Nil(t, err)
@@ -105,14 +105,14 @@ func TestRedisClusterSetWithTags(t *testing.T) {
 	cacheValue := "my-cache-value"
 
 	client := mocksStore.NewMockRedisClusterClientInterface(ctrl)
-	client.EXPECT().Set(context.TODO(), cacheKey, cacheValue, time.Duration(0)).Return(&redis.StatusCmd{})
-	client.EXPECT().SAdd(context.TODO(), "gocache_tag_tag1", "my-key").Return(&redis.IntCmd{})
-	client.EXPECT().Expire(context.TODO(), "gocache_tag_tag1", 720*time.Hour).Return(&redis.BoolCmd{})
+	client.EXPECT().Set(context.Background(), cacheKey, cacheValue, time.Duration(0)).Return(&redis.StatusCmd{})
+	client.EXPECT().SAdd(context.Background(), "gocache_tag_tag1", "my-key").Return(&redis.IntCmd{})
+	client.EXPECT().Expire(context.Background(), "gocache_tag_tag1", 720*time.Hour).Return(&redis.BoolCmd{})
 
 	store := NewRedisCluster(client, nil)
 
 	// When
-	err := store.Set(context.TODO(), cacheKey, cacheValue, &Options{Tags: []string{"tag1"}})
+	err := store.Set(cacheKey, cacheValue, &Options{Tags: []string{"tag1"}})
 
 	// Then
 	assert.Nil(t, err)
@@ -126,12 +126,12 @@ func TestRedisClusterDelete(t *testing.T) {
 	cacheKey := "my-key"
 
 	client := mocksStore.NewMockRedisClusterClientInterface(ctrl)
-	client.EXPECT().Del(context.TODO(), "my-key").Return(&redis.IntCmd{})
+	client.EXPECT().Del(context.Background(), "my-key").Return(&redis.IntCmd{})
 
 	store := NewRedisCluster(client, nil)
 
 	// When
-	err := store.Delete(context.TODO(), cacheKey)
+	err := store.Delete(cacheKey)
 
 	// Then
 	assert.Nil(t, err)
@@ -149,13 +149,13 @@ func TestRedisClusterInvalidate(t *testing.T) {
 	cacheKeys := &redis.StringSliceCmd{}
 
 	client := mocksStore.NewMockRedisClusterClientInterface(ctrl)
-	client.EXPECT().SMembers(context.TODO(), "gocache_tag_tag1").Return(cacheKeys)
-	client.EXPECT().Del(context.TODO(), "gocache_tag_tag1").Return(&redis.IntCmd{})
+	client.EXPECT().SMembers(context.Background(), "gocache_tag_tag1").Return(cacheKeys)
+	client.EXPECT().Del(context.Background(), "gocache_tag_tag1").Return(&redis.IntCmd{})
 
 	store := NewRedisCluster(client, nil)
 
 	// When
-	err := store.Invalidate(context.TODO(), options)
+	err := store.Invalidate(options)
 
 	// Then
 	assert.Nil(t, err)
@@ -167,12 +167,12 @@ func TestRedisClusterClear(t *testing.T) {
 	defer ctrl.Finish()
 
 	client := mocksStore.NewMockRedisClusterClientInterface(ctrl)
-	client.EXPECT().FlushAll(context.TODO()).Return(&redis.StatusCmd{})
+	client.EXPECT().FlushAll(context.Background()).Return(&redis.StatusCmd{})
 
 	store := NewRedisCluster(client, nil)
 
 	// When
-	err := store.Clear(context.TODO())
+	err := store.Clear()
 
 	// Then
 	assert.Nil(t, err)

--- a/store/ristretto.go
+++ b/store/ristretto.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	time "time"
+	"time"
 )
 
 const (


### PR DESCRIPTION
**Fix** cacheManager use redis/redis-cluster/pegasus with document that cause by context parameter:
![image](https://user-images.githubusercontent.com/45145345/116808861-a13f5780-ab6d-11eb-93a0-a381d473fe38.png)

![image](https://user-images.githubusercontent.com/45145345/116808845-8ec51e00-ab6d-11eb-947c-d166c5773fd1.png)

![image](https://user-images.githubusercontent.com/45145345/116808917-fed3a400-ab6d-11eb-8fcf-b3759237f0c1.png)

**Fixed result**:
![image](https://user-images.githubusercontent.com/45145345/116809014-aa7cf400-ab6e-11eb-985d-8d1940530111.png)

![image](https://user-images.githubusercontent.com/45145345/116809027-b799e300-ab6e-11eb-8a33-02e9db94d9e5.png)

**Local test result**:
[gocache_local_test.txt](https://github.com/eko/gocache/files/6411105/gocache_local_test.txt)




