### PR TITLE
Fix Race Condition in Memcached Store, Close Loadable to Stop Setter Routine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,5 @@ require (
 	github.com/spf13/cast v1.3.1
 	github.com/stretchr/testify v1.7.0
 	github.com/vmihailenco/msgpack v4.0.4+incompatible
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 )

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/store/memcache.go
+++ b/store/memcache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"golang.org/x/sync/errgroup"
 	"strings"
 	"time"
 
@@ -16,6 +17,8 @@ type MemcacheClientInterface interface {
 	Set(item *memcache.Item) error
 	Delete(item string) error
 	FlushAll() error
+	CompareAndSwap(item *memcache.Item) error
+	Add(item *memcache.Item) error
 }
 
 const (
@@ -23,6 +26,8 @@ const (
 	MemcacheType = "memcache"
 	// MemcacheTagPattern represents the tag pattern to be used as a key in specified storage
 	MemcacheTagPattern = "gocache_tag_%s"
+
+	TagKeyExpiry = 720 * time.Hour
 )
 
 // MemcacheStore is a store for Memcache
@@ -94,32 +99,66 @@ func (s *MemcacheStore) Set(ctx context.Context, key interface{}, value interfac
 }
 
 func (s *MemcacheStore) setTags(ctx context.Context, key interface{}, tags []string) {
+	group, ctx := errgroup.WithContext(ctx)
 	for _, tag := range tags {
-		var tagKey = fmt.Sprintf(MemcacheTagPattern, tag)
-		var cacheKeys = []string{}
+		currentTag := tag
+		group.Go(func() error {
+			var tagKey = fmt.Sprintf(MemcacheTagPattern, currentTag)
 
-		if result, err := s.Get(ctx, tagKey); err == nil {
-			if bytes, ok := result.([]byte); ok {
-				cacheKeys = strings.Split(string(bytes), ",")
+			var err error
+			for i := 0; i < 3; i++ {
+				if err = s.addKeyToTagValue(tagKey, key); err == nil {
+					return nil
+				}
+				// loop to retry any failure (including race conditions)
 			}
-		}
 
-		var alreadyInserted = false
-		for _, cacheKey := range cacheKeys {
-			if cacheKey == key.(string) {
-				alreadyInserted = true
-				break
-			}
-		}
-
-		if !alreadyInserted {
-			cacheKeys = append(cacheKeys, key.(string))
-		}
-
-		s.Set(ctx, tagKey, []byte(strings.Join(cacheKeys, ",")), &Options{
-			Expiration: 720 * time.Hour,
+			return err
 		})
 	}
+
+	group.Wait()
+}
+
+func (s *MemcacheStore) addKeyToTagValue(tagKey string, key interface{}) error {
+	var (
+		cacheKeys = []string{}
+		result    *memcache.Item
+		err       error
+	)
+
+	result, err = s.client.Get(tagKey)
+	if err == nil {
+		cacheKeys = strings.Split(string(result.Value), ",")
+	} else if !errors.Is(err, memcache.ErrCacheMiss) {
+		return err
+	}
+
+	for _, cacheKey := range cacheKeys {
+		// if key already exists, nothing to do
+		if cacheKey == key.(string) {
+			return nil
+		}
+	}
+
+	cacheKeys = append(cacheKeys, key.(string))
+
+	newVal := []byte(strings.Join(cacheKeys, ","))
+
+	if result == nil {
+		// if key didnt exist, use Add to create only if still not there
+		return s.client.Add(&memcache.Item{
+			Key:        tagKey,
+			Value:      newVal,
+			Expiration: int32(TagKeyExpiry.Seconds()),
+		})
+	}
+
+	// update existing value
+	// using CompareAndSwap to ensure not to run over writes between Get and here
+	result.Value = newVal
+	result.Expiration = int32(TagKeyExpiry.Seconds())
+	return s.client.CompareAndSwap(result)
 }
 
 // Delete removes data from Memcache for given key identifier
@@ -127,7 +166,7 @@ func (s *MemcacheStore) Delete(_ context.Context, key interface{}) error {
 	return s.client.Delete(key.(string))
 }
 
-// Invalidate invalidates some cache data in Redis for given options
+// Invalidate invalidates some cache data in Memcache for given options
 func (s *MemcacheStore) Invalidate(ctx context.Context, options InvalidateOptions) error {
 	if tags := options.TagsValue(); len(tags) > 0 {
 		for _, tag := range tags {

--- a/store/memcache_test.go
+++ b/store/memcache_test.go
@@ -250,9 +250,16 @@ func TestMemcacheSetWithTags(t *testing.T) {
 	cacheKey := "my-key"
 	cacheValue := []byte("my-cache-value")
 
+	tagKey := "gocache_tag_tag1"
+
 	client := mocksStore.NewMockMemcacheClientInterface(ctrl)
 	client.EXPECT().Set(gomock.Any()).AnyTimes().Return(nil)
-	client.EXPECT().Get("gocache_tag_tag1").Return(nil, nil)
+	client.EXPECT().Get(tagKey).Return(nil, memcache.ErrCacheMiss)
+	client.EXPECT().Add(&memcache.Item{
+		Key:        tagKey,
+		Value:      []byte(cacheKey),
+		Expiration: int32(TagKeyExpiry.Seconds()),
+	}).Return(nil)
 
 	store := NewMemcache(client, nil)
 

--- a/test/mocks/cache/cache_interface.go
+++ b/test/mocks/cache/cache_interface.go
@@ -6,37 +6,66 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+	time "time"
+
 	codec "github.com/eko/gocache/v2/codec"
 	store "github.com/eko/gocache/v2/store"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	time "time"
 )
 
-// MockCacheInterface is a mock of CacheInterface interface
+// MockCacheInterface is a mock of CacheInterface interface.
 type MockCacheInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockCacheInterfaceMockRecorder
 }
 
-// MockCacheInterfaceMockRecorder is the mock recorder for MockCacheInterface
+// MockCacheInterfaceMockRecorder is the mock recorder for MockCacheInterface.
 type MockCacheInterfaceMockRecorder struct {
 	mock *MockCacheInterface
 }
 
-// NewMockCacheInterface creates a new mock instance
+// NewMockCacheInterface creates a new mock instance.
 func NewMockCacheInterface(ctrl *gomock.Controller) *MockCacheInterface {
 	mock := &MockCacheInterface{ctrl: ctrl}
 	mock.recorder = &MockCacheInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCacheInterface) EXPECT() *MockCacheInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Clear mocks base method.
+func (m *MockCacheInterface) Clear(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clear", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Clear indicates an expected call of Clear.
+func (mr *MockCacheInterfaceMockRecorder) Clear(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockCacheInterface)(nil).Clear), ctx)
+}
+
+// Delete mocks base method.
+func (m *MockCacheInterface) Delete(ctx context.Context, key interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, key)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockCacheInterfaceMockRecorder) Delete(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCacheInterface)(nil).Delete), ctx, key)
+}
+
+// Get mocks base method.
 func (m *MockCacheInterface) Get(ctx context.Context, key interface{}) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", ctx, key)
@@ -45,69 +74,13 @@ func (m *MockCacheInterface) Get(ctx context.Context, key interface{}) (interfac
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockCacheInterfaceMockRecorder) Get(ctx, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCacheInterface)(nil).Get), ctx, key)
 }
 
-// Set mocks base method
-func (m *MockCacheInterface) Set(ctx context.Context, key, object interface{}, options *store.Options) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Set", ctx, key, object, options)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Set indicates an expected call of Set
-func (mr *MockCacheInterfaceMockRecorder) Set(ctx, key, object, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockCacheInterface)(nil).Set), ctx, key, object, options)
-}
-
-// Delete mocks base method
-func (m *MockCacheInterface) Delete(ctx context.Context, key interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, key)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete
-func (mr *MockCacheInterfaceMockRecorder) Delete(ctx, key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCacheInterface)(nil).Delete), ctx, key)
-}
-
-// Invalidate mocks base method
-func (m *MockCacheInterface) Invalidate(ctx context.Context, options store.InvalidateOptions) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Invalidate", ctx, options)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Invalidate indicates an expected call of Invalidate
-func (mr *MockCacheInterfaceMockRecorder) Invalidate(ctx, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Invalidate", reflect.TypeOf((*MockCacheInterface)(nil).Invalidate), ctx, options)
-}
-
-// Clear mocks base method
-func (m *MockCacheInterface) Clear(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Clear", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Clear indicates an expected call of Clear
-func (mr *MockCacheInterfaceMockRecorder) Clear(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockCacheInterface)(nil).Clear), ctx)
-}
-
-// GetType mocks base method
+// GetType mocks base method.
 func (m *MockCacheInterface) GetType() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetType")
@@ -115,36 +88,92 @@ func (m *MockCacheInterface) GetType() string {
 	return ret0
 }
 
-// GetType indicates an expected call of GetType
+// GetType indicates an expected call of GetType.
 func (mr *MockCacheInterfaceMockRecorder) GetType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetType", reflect.TypeOf((*MockCacheInterface)(nil).GetType))
 }
 
-// MockSetterCacheInterface is a mock of SetterCacheInterface interface
+// Invalidate mocks base method.
+func (m *MockCacheInterface) Invalidate(ctx context.Context, options store.InvalidateOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Invalidate", ctx, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Invalidate indicates an expected call of Invalidate.
+func (mr *MockCacheInterfaceMockRecorder) Invalidate(ctx, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Invalidate", reflect.TypeOf((*MockCacheInterface)(nil).Invalidate), ctx, options)
+}
+
+// Set mocks base method.
+func (m *MockCacheInterface) Set(ctx context.Context, key, object interface{}, options *store.Options) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Set", ctx, key, object, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Set indicates an expected call of Set.
+func (mr *MockCacheInterfaceMockRecorder) Set(ctx, key, object, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockCacheInterface)(nil).Set), ctx, key, object, options)
+}
+
+// MockSetterCacheInterface is a mock of SetterCacheInterface interface.
 type MockSetterCacheInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockSetterCacheInterfaceMockRecorder
 }
 
-// MockSetterCacheInterfaceMockRecorder is the mock recorder for MockSetterCacheInterface
+// MockSetterCacheInterfaceMockRecorder is the mock recorder for MockSetterCacheInterface.
 type MockSetterCacheInterfaceMockRecorder struct {
 	mock *MockSetterCacheInterface
 }
 
-// NewMockSetterCacheInterface creates a new mock instance
+// NewMockSetterCacheInterface creates a new mock instance.
 func NewMockSetterCacheInterface(ctrl *gomock.Controller) *MockSetterCacheInterface {
 	mock := &MockSetterCacheInterface{ctrl: ctrl}
 	mock.recorder = &MockSetterCacheInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockSetterCacheInterface) EXPECT() *MockSetterCacheInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Clear mocks base method.
+func (m *MockSetterCacheInterface) Clear(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clear", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Clear indicates an expected call of Clear.
+func (mr *MockSetterCacheInterfaceMockRecorder) Clear(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockSetterCacheInterface)(nil).Clear), ctx)
+}
+
+// Delete mocks base method.
+func (m *MockSetterCacheInterface) Delete(ctx context.Context, key interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, key)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockSetterCacheInterfaceMockRecorder) Delete(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockSetterCacheInterface)(nil).Delete), ctx, key)
+}
+
+// Get mocks base method.
 func (m *MockSetterCacheInterface) Get(ctx context.Context, key interface{}) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", ctx, key)
@@ -153,69 +182,27 @@ func (m *MockSetterCacheInterface) Get(ctx context.Context, key interface{}) (in
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockSetterCacheInterfaceMockRecorder) Get(ctx, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockSetterCacheInterface)(nil).Get), ctx, key)
 }
 
-// Set mocks base method
-func (m *MockSetterCacheInterface) Set(ctx context.Context, key, object interface{}, options *store.Options) error {
+// GetCodec mocks base method.
+func (m *MockSetterCacheInterface) GetCodec() codec.CodecInterface {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Set", ctx, key, object, options)
-	ret0, _ := ret[0].(error)
+	ret := m.ctrl.Call(m, "GetCodec")
+	ret0, _ := ret[0].(codec.CodecInterface)
 	return ret0
 }
 
-// Set indicates an expected call of Set
-func (mr *MockSetterCacheInterfaceMockRecorder) Set(ctx, key, object, options interface{}) *gomock.Call {
+// GetCodec indicates an expected call of GetCodec.
+func (mr *MockSetterCacheInterfaceMockRecorder) GetCodec() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockSetterCacheInterface)(nil).Set), ctx, key, object, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCodec", reflect.TypeOf((*MockSetterCacheInterface)(nil).GetCodec))
 }
 
-// Delete mocks base method
-func (m *MockSetterCacheInterface) Delete(ctx context.Context, key interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, key)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete
-func (mr *MockSetterCacheInterfaceMockRecorder) Delete(ctx, key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockSetterCacheInterface)(nil).Delete), ctx, key)
-}
-
-// Invalidate mocks base method
-func (m *MockSetterCacheInterface) Invalidate(ctx context.Context, options store.InvalidateOptions) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Invalidate", ctx, options)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Invalidate indicates an expected call of Invalidate
-func (mr *MockSetterCacheInterfaceMockRecorder) Invalidate(ctx, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Invalidate", reflect.TypeOf((*MockSetterCacheInterface)(nil).Invalidate), ctx, options)
-}
-
-// Clear mocks base method
-func (m *MockSetterCacheInterface) Clear(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Clear", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Clear indicates an expected call of Clear
-func (mr *MockSetterCacheInterfaceMockRecorder) Clear(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockSetterCacheInterface)(nil).Clear), ctx)
-}
-
-// GetType mocks base method
+// GetType mocks base method.
 func (m *MockSetterCacheInterface) GetType() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetType")
@@ -223,13 +210,13 @@ func (m *MockSetterCacheInterface) GetType() string {
 	return ret0
 }
 
-// GetType indicates an expected call of GetType
+// GetType indicates an expected call of GetType.
 func (mr *MockSetterCacheInterfaceMockRecorder) GetType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetType", reflect.TypeOf((*MockSetterCacheInterface)(nil).GetType))
 }
 
-// GetWithTTL mocks base method
+// GetWithTTL mocks base method.
 func (m *MockSetterCacheInterface) GetWithTTL(ctx context.Context, key interface{}) (interface{}, time.Duration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWithTTL", ctx, key)
@@ -239,22 +226,36 @@ func (m *MockSetterCacheInterface) GetWithTTL(ctx context.Context, key interface
 	return ret0, ret1, ret2
 }
 
-// GetWithTTL indicates an expected call of GetWithTTL
+// GetWithTTL indicates an expected call of GetWithTTL.
 func (mr *MockSetterCacheInterfaceMockRecorder) GetWithTTL(ctx, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithTTL", reflect.TypeOf((*MockSetterCacheInterface)(nil).GetWithTTL), ctx, key)
 }
 
-// GetCodec mocks base method
-func (m *MockSetterCacheInterface) GetCodec() codec.CodecInterface {
+// Invalidate mocks base method.
+func (m *MockSetterCacheInterface) Invalidate(ctx context.Context, options store.InvalidateOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCodec")
-	ret0, _ := ret[0].(codec.CodecInterface)
+	ret := m.ctrl.Call(m, "Invalidate", ctx, options)
+	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// GetCodec indicates an expected call of GetCodec
-func (mr *MockSetterCacheInterfaceMockRecorder) GetCodec() *gomock.Call {
+// Invalidate indicates an expected call of Invalidate.
+func (mr *MockSetterCacheInterfaceMockRecorder) Invalidate(ctx, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCodec", reflect.TypeOf((*MockSetterCacheInterface)(nil).GetCodec))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Invalidate", reflect.TypeOf((*MockSetterCacheInterface)(nil).Invalidate), ctx, options)
+}
+
+// Set mocks base method.
+func (m *MockSetterCacheInterface) Set(ctx context.Context, key, object interface{}, options *store.Options) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Set", ctx, key, object, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Set indicates an expected call of Set.
+func (mr *MockSetterCacheInterfaceMockRecorder) Set(ctx, key, object, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockSetterCacheInterface)(nil).Set), ctx, key, object, options)
 }

--- a/test/mocks/codec/codec_interface.go
+++ b/test/mocks/codec/codec_interface.go
@@ -6,37 +6,66 @@ package mocks
 
 import (
 	context "context"
+	reflect "reflect"
+	time "time"
+
 	codec "github.com/eko/gocache/v2/codec"
 	store "github.com/eko/gocache/v2/store"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
-	time "time"
 )
 
-// MockCodecInterface is a mock of CodecInterface interface
+// MockCodecInterface is a mock of CodecInterface interface.
 type MockCodecInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockCodecInterfaceMockRecorder
 }
 
-// MockCodecInterfaceMockRecorder is the mock recorder for MockCodecInterface
+// MockCodecInterfaceMockRecorder is the mock recorder for MockCodecInterface.
 type MockCodecInterfaceMockRecorder struct {
 	mock *MockCodecInterface
 }
 
-// NewMockCodecInterface creates a new mock instance
+// NewMockCodecInterface creates a new mock instance.
 func NewMockCodecInterface(ctrl *gomock.Controller) *MockCodecInterface {
 	mock := &MockCodecInterface{ctrl: ctrl}
 	mock.recorder = &MockCodecInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockCodecInterface) EXPECT() *MockCodecInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Clear mocks base method.
+func (m *MockCodecInterface) Clear(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clear", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Clear indicates an expected call of Clear.
+func (mr *MockCodecInterfaceMockRecorder) Clear(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockCodecInterface)(nil).Clear), ctx)
+}
+
+// Delete mocks base method.
+func (m *MockCodecInterface) Delete(ctx context.Context, key interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, key)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockCodecInterfaceMockRecorder) Delete(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCodecInterface)(nil).Delete), ctx, key)
+}
+
+// Get mocks base method.
 func (m *MockCodecInterface) Get(ctx context.Context, key interface{}) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", ctx, key)
@@ -45,13 +74,41 @@ func (m *MockCodecInterface) Get(ctx context.Context, key interface{}) (interfac
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockCodecInterfaceMockRecorder) Get(ctx, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCodecInterface)(nil).Get), ctx, key)
 }
 
-// GetWithTTL mocks base method
+// GetStats mocks base method.
+func (m *MockCodecInterface) GetStats() *codec.Stats {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStats")
+	ret0, _ := ret[0].(*codec.Stats)
+	return ret0
+}
+
+// GetStats indicates an expected call of GetStats.
+func (mr *MockCodecInterfaceMockRecorder) GetStats() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStats", reflect.TypeOf((*MockCodecInterface)(nil).GetStats))
+}
+
+// GetStore mocks base method.
+func (m *MockCodecInterface) GetStore() store.StoreInterface {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStore")
+	ret0, _ := ret[0].(store.StoreInterface)
+	return ret0
+}
+
+// GetStore indicates an expected call of GetStore.
+func (mr *MockCodecInterfaceMockRecorder) GetStore() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStore", reflect.TypeOf((*MockCodecInterface)(nil).GetStore))
+}
+
+// GetWithTTL mocks base method.
 func (m *MockCodecInterface) GetWithTTL(ctx context.Context, key interface{}) (interface{}, time.Duration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWithTTL", ctx, key)
@@ -61,41 +118,13 @@ func (m *MockCodecInterface) GetWithTTL(ctx context.Context, key interface{}) (i
 	return ret0, ret1, ret2
 }
 
-// GetWithTTL indicates an expected call of GetWithTTL
+// GetWithTTL indicates an expected call of GetWithTTL.
 func (mr *MockCodecInterfaceMockRecorder) GetWithTTL(ctx, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithTTL", reflect.TypeOf((*MockCodecInterface)(nil).GetWithTTL), ctx, key)
 }
 
-// Set mocks base method
-func (m *MockCodecInterface) Set(ctx context.Context, key, value interface{}, options *store.Options) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Set", ctx, key, value, options)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Set indicates an expected call of Set
-func (mr *MockCodecInterfaceMockRecorder) Set(ctx, key, value, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockCodecInterface)(nil).Set), ctx, key, value, options)
-}
-
-// Delete mocks base method
-func (m *MockCodecInterface) Delete(ctx context.Context, key interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, key)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete
-func (mr *MockCodecInterfaceMockRecorder) Delete(ctx, key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCodecInterface)(nil).Delete), ctx, key)
-}
-
-// Invalidate mocks base method
+// Invalidate mocks base method.
 func (m *MockCodecInterface) Invalidate(ctx context.Context, options store.InvalidateOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Invalidate", ctx, options)
@@ -103,50 +132,22 @@ func (m *MockCodecInterface) Invalidate(ctx context.Context, options store.Inval
 	return ret0
 }
 
-// Invalidate indicates an expected call of Invalidate
+// Invalidate indicates an expected call of Invalidate.
 func (mr *MockCodecInterfaceMockRecorder) Invalidate(ctx, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Invalidate", reflect.TypeOf((*MockCodecInterface)(nil).Invalidate), ctx, options)
 }
 
-// Clear mocks base method
-func (m *MockCodecInterface) Clear(ctx context.Context) error {
+// Set mocks base method.
+func (m *MockCodecInterface) Set(ctx context.Context, key, value interface{}, options *store.Options) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Clear", ctx)
+	ret := m.ctrl.Call(m, "Set", ctx, key, value, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Clear indicates an expected call of Clear
-func (mr *MockCodecInterfaceMockRecorder) Clear(ctx interface{}) *gomock.Call {
+// Set indicates an expected call of Set.
+func (mr *MockCodecInterfaceMockRecorder) Set(ctx, key, value, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockCodecInterface)(nil).Clear), ctx)
-}
-
-// GetStore mocks base method
-func (m *MockCodecInterface) GetStore() store.StoreInterface {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStore")
-	ret0, _ := ret[0].(store.StoreInterface)
-	return ret0
-}
-
-// GetStore indicates an expected call of GetStore
-func (mr *MockCodecInterfaceMockRecorder) GetStore() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStore", reflect.TypeOf((*MockCodecInterface)(nil).GetStore))
-}
-
-// GetStats mocks base method
-func (m *MockCodecInterface) GetStats() *codec.Stats {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetStats")
-	ret0, _ := ret[0].(*codec.Stats)
-	return ret0
-}
-
-// GetStats indicates an expected call of GetStats
-func (mr *MockCodecInterfaceMockRecorder) GetStats() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStats", reflect.TypeOf((*MockCodecInterface)(nil).GetStats))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockCodecInterface)(nil).Set), ctx, key, value, options)
 }

--- a/test/mocks/metrics/metrics_interface.go
+++ b/test/mocks/metrics/metrics_interface.go
@@ -5,41 +5,42 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	codec "github.com/eko/gocache/v2/codec"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockMetricsInterface is a mock of MetricsInterface interface
+// MockMetricsInterface is a mock of MetricsInterface interface.
 type MockMetricsInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockMetricsInterfaceMockRecorder
 }
 
-// MockMetricsInterfaceMockRecorder is the mock recorder for MockMetricsInterface
+// MockMetricsInterfaceMockRecorder is the mock recorder for MockMetricsInterface.
 type MockMetricsInterfaceMockRecorder struct {
 	mock *MockMetricsInterface
 }
 
-// NewMockMetricsInterface creates a new mock instance
+// NewMockMetricsInterface creates a new mock instance.
 func NewMockMetricsInterface(ctrl *gomock.Controller) *MockMetricsInterface {
 	mock := &MockMetricsInterface{ctrl: ctrl}
 	mock.recorder = &MockMetricsInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMetricsInterface) EXPECT() *MockMetricsInterfaceMockRecorder {
 	return m.recorder
 }
 
-// RecordFromCodec mocks base method
+// RecordFromCodec mocks base method.
 func (m *MockMetricsInterface) RecordFromCodec(codec codec.CodecInterface) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "RecordFromCodec", codec)
 }
 
-// RecordFromCodec indicates an expected call of RecordFromCodec
+// RecordFromCodec indicates an expected call of RecordFromCodec.
 func (mr *MockMetricsInterfaceMockRecorder) RecordFromCodec(codec interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordFromCodec", reflect.TypeOf((*MockMetricsInterface)(nil).RecordFromCodec), codec)

--- a/test/mocks/store/clients/bigcache_interface.go
+++ b/test/mocks/store/clients/bigcache_interface.go
@@ -5,34 +5,49 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockBigcacheClientInterface is a mock of BigcacheClientInterface interface
+// MockBigcacheClientInterface is a mock of BigcacheClientInterface interface.
 type MockBigcacheClientInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockBigcacheClientInterfaceMockRecorder
 }
 
-// MockBigcacheClientInterfaceMockRecorder is the mock recorder for MockBigcacheClientInterface
+// MockBigcacheClientInterfaceMockRecorder is the mock recorder for MockBigcacheClientInterface.
 type MockBigcacheClientInterfaceMockRecorder struct {
 	mock *MockBigcacheClientInterface
 }
 
-// NewMockBigcacheClientInterface creates a new mock instance
+// NewMockBigcacheClientInterface creates a new mock instance.
 func NewMockBigcacheClientInterface(ctrl *gomock.Controller) *MockBigcacheClientInterface {
 	mock := &MockBigcacheClientInterface{ctrl: ctrl}
 	mock.recorder = &MockBigcacheClientInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBigcacheClientInterface) EXPECT() *MockBigcacheClientInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Delete mocks base method.
+func (m *MockBigcacheClientInterface) Delete(key string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", key)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockBigcacheClientInterfaceMockRecorder) Delete(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockBigcacheClientInterface)(nil).Delete), key)
+}
+
+// Get mocks base method.
 func (m *MockBigcacheClientInterface) Get(key string) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", key)
@@ -41,41 +56,13 @@ func (m *MockBigcacheClientInterface) Get(key string) ([]byte, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockBigcacheClientInterfaceMockRecorder) Get(key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockBigcacheClientInterface)(nil).Get), key)
 }
 
-// Set mocks base method
-func (m *MockBigcacheClientInterface) Set(key string, entry []byte) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Set", key, entry)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Set indicates an expected call of Set
-func (mr *MockBigcacheClientInterfaceMockRecorder) Set(key, entry interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockBigcacheClientInterface)(nil).Set), key, entry)
-}
-
-// Delete mocks base method
-func (m *MockBigcacheClientInterface) Delete(key string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", key)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete
-func (mr *MockBigcacheClientInterfaceMockRecorder) Delete(key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockBigcacheClientInterface)(nil).Delete), key)
-}
-
-// Reset mocks base method
+// Reset mocks base method.
 func (m *MockBigcacheClientInterface) Reset() error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reset")
@@ -83,8 +70,22 @@ func (m *MockBigcacheClientInterface) Reset() error {
 	return ret0
 }
 
-// Reset indicates an expected call of Reset
+// Reset indicates an expected call of Reset.
 func (mr *MockBigcacheClientInterfaceMockRecorder) Reset() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockBigcacheClientInterface)(nil).Reset))
+}
+
+// Set mocks base method.
+func (m *MockBigcacheClientInterface) Set(key string, entry []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Set", key, entry)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Set indicates an expected call of Set.
+func (mr *MockBigcacheClientInterfaceMockRecorder) Set(key, entry interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockBigcacheClientInterface)(nil).Set), key, entry)
 }

--- a/test/mocks/store/clients/freecache_interface.go
+++ b/test/mocks/store/clients/freecache_interface.go
@@ -5,34 +5,75 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockFreecacheClientInterface is a mock of FreecacheClientInterface interface
+// MockFreecacheClientInterface is a mock of FreecacheClientInterface interface.
 type MockFreecacheClientInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockFreecacheClientInterfaceMockRecorder
 }
 
-// MockFreecacheClientInterfaceMockRecorder is the mock recorder for MockFreecacheClientInterface
+// MockFreecacheClientInterfaceMockRecorder is the mock recorder for MockFreecacheClientInterface.
 type MockFreecacheClientInterfaceMockRecorder struct {
 	mock *MockFreecacheClientInterface
 }
 
-// NewMockFreecacheClientInterface creates a new mock instance
+// NewMockFreecacheClientInterface creates a new mock instance.
 func NewMockFreecacheClientInterface(ctrl *gomock.Controller) *MockFreecacheClientInterface {
 	mock := &MockFreecacheClientInterface{ctrl: ctrl}
 	mock.recorder = &MockFreecacheClientInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockFreecacheClientInterface) EXPECT() *MockFreecacheClientInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Clear mocks base method.
+func (m *MockFreecacheClientInterface) Clear() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Clear")
+}
+
+// Clear indicates an expected call of Clear.
+func (mr *MockFreecacheClientInterfaceMockRecorder) Clear() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockFreecacheClientInterface)(nil).Clear))
+}
+
+// Del mocks base method.
+func (m *MockFreecacheClientInterface) Del(key []byte) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Del", key)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Del indicates an expected call of Del.
+func (mr *MockFreecacheClientInterfaceMockRecorder) Del(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockFreecacheClientInterface)(nil).Del), key)
+}
+
+// DelInt mocks base method.
+func (m *MockFreecacheClientInterface) DelInt(key int64) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DelInt", key)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// DelInt indicates an expected call of DelInt.
+func (mr *MockFreecacheClientInterfaceMockRecorder) DelInt(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelInt", reflect.TypeOf((*MockFreecacheClientInterface)(nil).DelInt), key)
+}
+
+// Get mocks base method.
 func (m *MockFreecacheClientInterface) Get(key []byte) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", key)
@@ -41,13 +82,13 @@ func (m *MockFreecacheClientInterface) Get(key []byte) ([]byte, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockFreecacheClientInterfaceMockRecorder) Get(key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockFreecacheClientInterface)(nil).Get), key)
 }
 
-// GetInt mocks base method
+// GetInt mocks base method.
 func (m *MockFreecacheClientInterface) GetInt(key int64) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetInt", key)
@@ -56,13 +97,41 @@ func (m *MockFreecacheClientInterface) GetInt(key int64) ([]byte, error) {
 	return ret0, ret1
 }
 
-// GetInt indicates an expected call of GetInt
+// GetInt indicates an expected call of GetInt.
 func (mr *MockFreecacheClientInterfaceMockRecorder) GetInt(key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInt", reflect.TypeOf((*MockFreecacheClientInterface)(nil).GetInt), key)
 }
 
-// TTL mocks base method
+// Set mocks base method.
+func (m *MockFreecacheClientInterface) Set(key, value []byte, expireSeconds int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Set", key, value, expireSeconds)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Set indicates an expected call of Set.
+func (mr *MockFreecacheClientInterfaceMockRecorder) Set(key, value, expireSeconds interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockFreecacheClientInterface)(nil).Set), key, value, expireSeconds)
+}
+
+// SetInt mocks base method.
+func (m *MockFreecacheClientInterface) SetInt(key int64, value []byte, expireSeconds int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetInt", key, value, expireSeconds)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetInt indicates an expected call of SetInt.
+func (mr *MockFreecacheClientInterfaceMockRecorder) SetInt(key, value, expireSeconds interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInt", reflect.TypeOf((*MockFreecacheClientInterface)(nil).SetInt), key, value, expireSeconds)
+}
+
+// TTL mocks base method.
 func (m *MockFreecacheClientInterface) TTL(key []byte) (uint32, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TTL", key)
@@ -71,76 +140,8 @@ func (m *MockFreecacheClientInterface) TTL(key []byte) (uint32, error) {
 	return ret0, ret1
 }
 
-// TTL indicates an expected call of TTL
+// TTL indicates an expected call of TTL.
 func (mr *MockFreecacheClientInterfaceMockRecorder) TTL(key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TTL", reflect.TypeOf((*MockFreecacheClientInterface)(nil).TTL), key)
-}
-
-// Set mocks base method
-func (m *MockFreecacheClientInterface) Set(key, value []byte, expireSeconds int) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Set", key, value, expireSeconds)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Set indicates an expected call of Set
-func (mr *MockFreecacheClientInterfaceMockRecorder) Set(key, value, expireSeconds interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockFreecacheClientInterface)(nil).Set), key, value, expireSeconds)
-}
-
-// SetInt mocks base method
-func (m *MockFreecacheClientInterface) SetInt(key int64, value []byte, expireSeconds int) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetInt", key, value, expireSeconds)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetInt indicates an expected call of SetInt
-func (mr *MockFreecacheClientInterfaceMockRecorder) SetInt(key, value, expireSeconds interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetInt", reflect.TypeOf((*MockFreecacheClientInterface)(nil).SetInt), key, value, expireSeconds)
-}
-
-// Del mocks base method
-func (m *MockFreecacheClientInterface) Del(key []byte) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Del", key)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// Del indicates an expected call of Del
-func (mr *MockFreecacheClientInterfaceMockRecorder) Del(key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockFreecacheClientInterface)(nil).Del), key)
-}
-
-// DelInt mocks base method
-func (m *MockFreecacheClientInterface) DelInt(key int64) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DelInt", key)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// DelInt indicates an expected call of DelInt
-func (mr *MockFreecacheClientInterfaceMockRecorder) DelInt(key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelInt", reflect.TypeOf((*MockFreecacheClientInterface)(nil).DelInt), key)
-}
-
-// Clear mocks base method
-func (m *MockFreecacheClientInterface) Clear() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Clear")
-}
-
-// Clear indicates an expected call of Clear
-func (mr *MockFreecacheClientInterfaceMockRecorder) Clear() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockFreecacheClientInterface)(nil).Clear))
 }

--- a/test/mocks/store/clients/go_cache_interface.go
+++ b/test/mocks/store/clients/go_cache_interface.go
@@ -5,35 +5,60 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockGoCacheClientInterface is a mock of GoCacheClientInterface interface
+// MockGoCacheClientInterface is a mock of GoCacheClientInterface interface.
 type MockGoCacheClientInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockGoCacheClientInterfaceMockRecorder
 }
 
-// MockGoCacheClientInterfaceMockRecorder is the mock recorder for MockGoCacheClientInterface
+// MockGoCacheClientInterfaceMockRecorder is the mock recorder for MockGoCacheClientInterface.
 type MockGoCacheClientInterfaceMockRecorder struct {
 	mock *MockGoCacheClientInterface
 }
 
-// NewMockGoCacheClientInterface creates a new mock instance
+// NewMockGoCacheClientInterface creates a new mock instance.
 func NewMockGoCacheClientInterface(ctrl *gomock.Controller) *MockGoCacheClientInterface {
 	mock := &MockGoCacheClientInterface{ctrl: ctrl}
 	mock.recorder = &MockGoCacheClientInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockGoCacheClientInterface) EXPECT() *MockGoCacheClientInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Delete mocks base method.
+func (m *MockGoCacheClientInterface) Delete(k string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Delete", k)
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockGoCacheClientInterfaceMockRecorder) Delete(k interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockGoCacheClientInterface)(nil).Delete), k)
+}
+
+// Flush mocks base method.
+func (m *MockGoCacheClientInterface) Flush() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Flush")
+}
+
+// Flush indicates an expected call of Flush.
+func (mr *MockGoCacheClientInterfaceMockRecorder) Flush() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockGoCacheClientInterface)(nil).Flush))
+}
+
+// Get mocks base method.
 func (m *MockGoCacheClientInterface) Get(k string) (interface{}, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", k)
@@ -42,13 +67,13 @@ func (m *MockGoCacheClientInterface) Get(k string) (interface{}, bool) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockGoCacheClientInterfaceMockRecorder) Get(k interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockGoCacheClientInterface)(nil).Get), k)
 }
 
-// GetWithExpiration mocks base method
+// GetWithExpiration mocks base method.
 func (m *MockGoCacheClientInterface) GetWithExpiration(k string) (interface{}, time.Time, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWithExpiration", k)
@@ -58,44 +83,20 @@ func (m *MockGoCacheClientInterface) GetWithExpiration(k string) (interface{}, t
 	return ret0, ret1, ret2
 }
 
-// GetWithExpiration indicates an expected call of GetWithExpiration
+// GetWithExpiration indicates an expected call of GetWithExpiration.
 func (mr *MockGoCacheClientInterfaceMockRecorder) GetWithExpiration(k interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithExpiration", reflect.TypeOf((*MockGoCacheClientInterface)(nil).GetWithExpiration), k)
 }
 
-// Set mocks base method
+// Set mocks base method.
 func (m *MockGoCacheClientInterface) Set(k string, x interface{}, d time.Duration) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Set", k, x, d)
 }
 
-// Set indicates an expected call of Set
+// Set indicates an expected call of Set.
 func (mr *MockGoCacheClientInterfaceMockRecorder) Set(k, x, d interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockGoCacheClientInterface)(nil).Set), k, x, d)
-}
-
-// Delete mocks base method
-func (m *MockGoCacheClientInterface) Delete(k string) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Delete", k)
-}
-
-// Delete indicates an expected call of Delete
-func (mr *MockGoCacheClientInterfaceMockRecorder) Delete(k interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockGoCacheClientInterface)(nil).Delete), k)
-}
-
-// Flush mocks base method
-func (m *MockGoCacheClientInterface) Flush() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Flush")
-}
-
-// Flush indicates an expected call of Flush
-func (mr *MockGoCacheClientInterfaceMockRecorder) Flush() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Flush", reflect.TypeOf((*MockGoCacheClientInterface)(nil).Flush))
 }

--- a/test/mocks/store/clients/memcache_interface.go
+++ b/test/mocks/store/clients/memcache_interface.go
@@ -5,35 +5,92 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	memcache "github.com/bradfitz/gomemcache/memcache"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockMemcacheClientInterface is a mock of MemcacheClientInterface interface
+// MockMemcacheClientInterface is a mock of MemcacheClientInterface interface.
 type MockMemcacheClientInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockMemcacheClientInterfaceMockRecorder
 }
 
-// MockMemcacheClientInterfaceMockRecorder is the mock recorder for MockMemcacheClientInterface
+// MockMemcacheClientInterfaceMockRecorder is the mock recorder for MockMemcacheClientInterface.
 type MockMemcacheClientInterfaceMockRecorder struct {
 	mock *MockMemcacheClientInterface
 }
 
-// NewMockMemcacheClientInterface creates a new mock instance
+// NewMockMemcacheClientInterface creates a new mock instance.
 func NewMockMemcacheClientInterface(ctrl *gomock.Controller) *MockMemcacheClientInterface {
 	mock := &MockMemcacheClientInterface{ctrl: ctrl}
 	mock.recorder = &MockMemcacheClientInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockMemcacheClientInterface) EXPECT() *MockMemcacheClientInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Add mocks base method.
+func (m *MockMemcacheClientInterface) Add(item *memcache.Item) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Add", item)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Add indicates an expected call of Add.
+func (mr *MockMemcacheClientInterfaceMockRecorder) Add(item interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockMemcacheClientInterface)(nil).Add), item)
+}
+
+// CompareAndSwap mocks base method.
+func (m *MockMemcacheClientInterface) CompareAndSwap(item *memcache.Item) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CompareAndSwap", item)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CompareAndSwap indicates an expected call of CompareAndSwap.
+func (mr *MockMemcacheClientInterfaceMockRecorder) CompareAndSwap(item interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompareAndSwap", reflect.TypeOf((*MockMemcacheClientInterface)(nil).CompareAndSwap), item)
+}
+
+// Delete mocks base method.
+func (m *MockMemcacheClientInterface) Delete(item string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", item)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockMemcacheClientInterfaceMockRecorder) Delete(item interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockMemcacheClientInterface)(nil).Delete), item)
+}
+
+// FlushAll mocks base method.
+func (m *MockMemcacheClientInterface) FlushAll() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FlushAll")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// FlushAll indicates an expected call of FlushAll.
+func (mr *MockMemcacheClientInterfaceMockRecorder) FlushAll() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushAll", reflect.TypeOf((*MockMemcacheClientInterface)(nil).FlushAll))
+}
+
+// Get mocks base method.
 func (m *MockMemcacheClientInterface) Get(key string) (*memcache.Item, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", key)
@@ -42,13 +99,13 @@ func (m *MockMemcacheClientInterface) Get(key string) (*memcache.Item, error) {
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockMemcacheClientInterfaceMockRecorder) Get(key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockMemcacheClientInterface)(nil).Get), key)
 }
 
-// Set mocks base method
+// Set mocks base method.
 func (m *MockMemcacheClientInterface) Set(item *memcache.Item) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Set", item)
@@ -56,36 +113,8 @@ func (m *MockMemcacheClientInterface) Set(item *memcache.Item) error {
 	return ret0
 }
 
-// Set indicates an expected call of Set
+// Set indicates an expected call of Set.
 func (mr *MockMemcacheClientInterfaceMockRecorder) Set(item interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockMemcacheClientInterface)(nil).Set), item)
-}
-
-// Delete mocks base method
-func (m *MockMemcacheClientInterface) Delete(item string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", item)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete
-func (mr *MockMemcacheClientInterfaceMockRecorder) Delete(item interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockMemcacheClientInterface)(nil).Delete), item)
-}
-
-// FlushAll mocks base method
-func (m *MockMemcacheClientInterface) FlushAll() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FlushAll")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// FlushAll indicates an expected call of FlushAll
-func (mr *MockMemcacheClientInterfaceMockRecorder) FlushAll() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushAll", reflect.TypeOf((*MockMemcacheClientInterface)(nil).FlushAll))
 }

--- a/test/mocks/store/clients/redis_interface.go
+++ b/test/mocks/store/clients/redis_interface.go
@@ -6,92 +6,37 @@ package mocks
 
 import (
 	context "context"
-	redis "github.com/go-redis/redis/v8"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	redis "github.com/go-redis/redis/v8"
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockRedisClientInterface is a mock of RedisClientInterface interface
+// MockRedisClientInterface is a mock of RedisClientInterface interface.
 type MockRedisClientInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockRedisClientInterfaceMockRecorder
 }
 
-// MockRedisClientInterfaceMockRecorder is the mock recorder for MockRedisClientInterface
+// MockRedisClientInterfaceMockRecorder is the mock recorder for MockRedisClientInterface.
 type MockRedisClientInterfaceMockRecorder struct {
 	mock *MockRedisClientInterface
 }
 
-// NewMockRedisClientInterface creates a new mock instance
+// NewMockRedisClientInterface creates a new mock instance.
 func NewMockRedisClientInterface(ctrl *gomock.Controller) *MockRedisClientInterface {
 	mock := &MockRedisClientInterface{ctrl: ctrl}
 	mock.recorder = &MockRedisClientInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRedisClientInterface) EXPECT() *MockRedisClientInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
-func (m *MockRedisClientInterface) Get(ctx context.Context, key string) *redis.StringCmd {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", ctx, key)
-	ret0, _ := ret[0].(*redis.StringCmd)
-	return ret0
-}
-
-// Get indicates an expected call of Get
-func (mr *MockRedisClientInterfaceMockRecorder) Get(ctx, key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRedisClientInterface)(nil).Get), ctx, key)
-}
-
-// TTL mocks base method
-func (m *MockRedisClientInterface) TTL(ctx context.Context, key string) *redis.DurationCmd {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TTL", ctx, key)
-	ret0, _ := ret[0].(*redis.DurationCmd)
-	return ret0
-}
-
-// TTL indicates an expected call of TTL
-func (mr *MockRedisClientInterfaceMockRecorder) TTL(ctx, key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TTL", reflect.TypeOf((*MockRedisClientInterface)(nil).TTL), ctx, key)
-}
-
-// Expire mocks base method
-func (m *MockRedisClientInterface) Expire(ctx context.Context, key string, expiration time.Duration) *redis.BoolCmd {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Expire", ctx, key, expiration)
-	ret0, _ := ret[0].(*redis.BoolCmd)
-	return ret0
-}
-
-// Expire indicates an expected call of Expire
-func (mr *MockRedisClientInterfaceMockRecorder) Expire(ctx, key, expiration interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expire", reflect.TypeOf((*MockRedisClientInterface)(nil).Expire), ctx, key, expiration)
-}
-
-// Set mocks base method
-func (m *MockRedisClientInterface) Set(ctx context.Context, key string, values interface{}, expiration time.Duration) *redis.StatusCmd {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Set", ctx, key, values, expiration)
-	ret0, _ := ret[0].(*redis.StatusCmd)
-	return ret0
-}
-
-// Set indicates an expected call of Set
-func (mr *MockRedisClientInterfaceMockRecorder) Set(ctx, key, values, expiration interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockRedisClientInterface)(nil).Set), ctx, key, values, expiration)
-}
-
-// Del mocks base method
+// Del mocks base method.
 func (m *MockRedisClientInterface) Del(ctx context.Context, keys ...string) *redis.IntCmd {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx}
@@ -103,14 +48,28 @@ func (m *MockRedisClientInterface) Del(ctx context.Context, keys ...string) *red
 	return ret0
 }
 
-// Del indicates an expected call of Del
+// Del indicates an expected call of Del.
 func (mr *MockRedisClientInterfaceMockRecorder) Del(ctx interface{}, keys ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx}, keys...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockRedisClientInterface)(nil).Del), varargs...)
 }
 
-// FlushAll mocks base method
+// Expire mocks base method.
+func (m *MockRedisClientInterface) Expire(ctx context.Context, key string, expiration time.Duration) *redis.BoolCmd {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Expire", ctx, key, expiration)
+	ret0, _ := ret[0].(*redis.BoolCmd)
+	return ret0
+}
+
+// Expire indicates an expected call of Expire.
+func (mr *MockRedisClientInterfaceMockRecorder) Expire(ctx, key, expiration interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expire", reflect.TypeOf((*MockRedisClientInterface)(nil).Expire), ctx, key, expiration)
+}
+
+// FlushAll mocks base method.
 func (m *MockRedisClientInterface) FlushAll(ctx context.Context) *redis.StatusCmd {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FlushAll", ctx)
@@ -118,13 +77,27 @@ func (m *MockRedisClientInterface) FlushAll(ctx context.Context) *redis.StatusCm
 	return ret0
 }
 
-// FlushAll indicates an expected call of FlushAll
+// FlushAll indicates an expected call of FlushAll.
 func (mr *MockRedisClientInterfaceMockRecorder) FlushAll(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushAll", reflect.TypeOf((*MockRedisClientInterface)(nil).FlushAll), ctx)
 }
 
-// SAdd mocks base method
+// Get mocks base method.
+func (m *MockRedisClientInterface) Get(ctx context.Context, key string) *redis.StringCmd {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, key)
+	ret0, _ := ret[0].(*redis.StringCmd)
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockRedisClientInterfaceMockRecorder) Get(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRedisClientInterface)(nil).Get), ctx, key)
+}
+
+// SAdd mocks base method.
 func (m *MockRedisClientInterface) SAdd(ctx context.Context, key string, members ...interface{}) *redis.IntCmd {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, key}
@@ -136,14 +109,14 @@ func (m *MockRedisClientInterface) SAdd(ctx context.Context, key string, members
 	return ret0
 }
 
-// SAdd indicates an expected call of SAdd
+// SAdd indicates an expected call of SAdd.
 func (mr *MockRedisClientInterfaceMockRecorder) SAdd(ctx, key interface{}, members ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, key}, members...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SAdd", reflect.TypeOf((*MockRedisClientInterface)(nil).SAdd), varargs...)
 }
 
-// SMembers mocks base method
+// SMembers mocks base method.
 func (m *MockRedisClientInterface) SMembers(ctx context.Context, key string) *redis.StringSliceCmd {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SMembers", ctx, key)
@@ -151,8 +124,36 @@ func (m *MockRedisClientInterface) SMembers(ctx context.Context, key string) *re
 	return ret0
 }
 
-// SMembers indicates an expected call of SMembers
+// SMembers indicates an expected call of SMembers.
 func (mr *MockRedisClientInterfaceMockRecorder) SMembers(ctx, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SMembers", reflect.TypeOf((*MockRedisClientInterface)(nil).SMembers), ctx, key)
+}
+
+// Set mocks base method.
+func (m *MockRedisClientInterface) Set(ctx context.Context, key string, values interface{}, expiration time.Duration) *redis.StatusCmd {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Set", ctx, key, values, expiration)
+	ret0, _ := ret[0].(*redis.StatusCmd)
+	return ret0
+}
+
+// Set indicates an expected call of Set.
+func (mr *MockRedisClientInterfaceMockRecorder) Set(ctx, key, values, expiration interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockRedisClientInterface)(nil).Set), ctx, key, values, expiration)
+}
+
+// TTL mocks base method.
+func (m *MockRedisClientInterface) TTL(ctx context.Context, key string) *redis.DurationCmd {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TTL", ctx, key)
+	ret0, _ := ret[0].(*redis.DurationCmd)
+	return ret0
+}
+
+// TTL indicates an expected call of TTL.
+func (mr *MockRedisClientInterfaceMockRecorder) TTL(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TTL", reflect.TypeOf((*MockRedisClientInterface)(nil).TTL), ctx, key)
 }

--- a/test/mocks/store/clients/rediscluster_interface.go
+++ b/test/mocks/store/clients/rediscluster_interface.go
@@ -6,92 +6,37 @@ package mocks
 
 import (
 	context "context"
-	redis "github.com/go-redis/redis/v8"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	redis "github.com/go-redis/redis/v8"
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockRedisClusterClientInterface is a mock of RedisClusterClientInterface interface
+// MockRedisClusterClientInterface is a mock of RedisClusterClientInterface interface.
 type MockRedisClusterClientInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockRedisClusterClientInterfaceMockRecorder
 }
 
-// MockRedisClusterClientInterfaceMockRecorder is the mock recorder for MockRedisClusterClientInterface
+// MockRedisClusterClientInterfaceMockRecorder is the mock recorder for MockRedisClusterClientInterface.
 type MockRedisClusterClientInterfaceMockRecorder struct {
 	mock *MockRedisClusterClientInterface
 }
 
-// NewMockRedisClusterClientInterface creates a new mock instance
+// NewMockRedisClusterClientInterface creates a new mock instance.
 func NewMockRedisClusterClientInterface(ctrl *gomock.Controller) *MockRedisClusterClientInterface {
 	mock := &MockRedisClusterClientInterface{ctrl: ctrl}
 	mock.recorder = &MockRedisClusterClientInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRedisClusterClientInterface) EXPECT() *MockRedisClusterClientInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
-func (m *MockRedisClusterClientInterface) Get(ctx context.Context, key string) *redis.StringCmd {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", ctx, key)
-	ret0, _ := ret[0].(*redis.StringCmd)
-	return ret0
-}
-
-// Get indicates an expected call of Get
-func (mr *MockRedisClusterClientInterfaceMockRecorder) Get(ctx, key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).Get), ctx, key)
-}
-
-// TTL mocks base method
-func (m *MockRedisClusterClientInterface) TTL(ctx context.Context, key string) *redis.DurationCmd {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TTL", ctx, key)
-	ret0, _ := ret[0].(*redis.DurationCmd)
-	return ret0
-}
-
-// TTL indicates an expected call of TTL
-func (mr *MockRedisClusterClientInterfaceMockRecorder) TTL(ctx, key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TTL", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).TTL), ctx, key)
-}
-
-// Expire mocks base method
-func (m *MockRedisClusterClientInterface) Expire(ctx context.Context, key string, expiration time.Duration) *redis.BoolCmd {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Expire", ctx, key, expiration)
-	ret0, _ := ret[0].(*redis.BoolCmd)
-	return ret0
-}
-
-// Expire indicates an expected call of Expire
-func (mr *MockRedisClusterClientInterfaceMockRecorder) Expire(ctx, key, expiration interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expire", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).Expire), ctx, key, expiration)
-}
-
-// Set mocks base method
-func (m *MockRedisClusterClientInterface) Set(ctx context.Context, key string, values interface{}, expiration time.Duration) *redis.StatusCmd {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Set", ctx, key, values, expiration)
-	ret0, _ := ret[0].(*redis.StatusCmd)
-	return ret0
-}
-
-// Set indicates an expected call of Set
-func (mr *MockRedisClusterClientInterfaceMockRecorder) Set(ctx, key, values, expiration interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).Set), ctx, key, values, expiration)
-}
-
-// Del mocks base method
+// Del mocks base method.
 func (m *MockRedisClusterClientInterface) Del(ctx context.Context, keys ...string) *redis.IntCmd {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx}
@@ -103,14 +48,28 @@ func (m *MockRedisClusterClientInterface) Del(ctx context.Context, keys ...strin
 	return ret0
 }
 
-// Del indicates an expected call of Del
+// Del indicates an expected call of Del.
 func (mr *MockRedisClusterClientInterfaceMockRecorder) Del(ctx interface{}, keys ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx}, keys...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).Del), varargs...)
 }
 
-// FlushAll mocks base method
+// Expire mocks base method.
+func (m *MockRedisClusterClientInterface) Expire(ctx context.Context, key string, expiration time.Duration) *redis.BoolCmd {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Expire", ctx, key, expiration)
+	ret0, _ := ret[0].(*redis.BoolCmd)
+	return ret0
+}
+
+// Expire indicates an expected call of Expire.
+func (mr *MockRedisClusterClientInterfaceMockRecorder) Expire(ctx, key, expiration interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Expire", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).Expire), ctx, key, expiration)
+}
+
+// FlushAll mocks base method.
 func (m *MockRedisClusterClientInterface) FlushAll(ctx context.Context) *redis.StatusCmd {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FlushAll", ctx)
@@ -118,13 +77,27 @@ func (m *MockRedisClusterClientInterface) FlushAll(ctx context.Context) *redis.S
 	return ret0
 }
 
-// FlushAll indicates an expected call of FlushAll
+// FlushAll indicates an expected call of FlushAll.
 func (mr *MockRedisClusterClientInterfaceMockRecorder) FlushAll(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FlushAll", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).FlushAll), ctx)
 }
 
-// SAdd mocks base method
+// Get mocks base method.
+func (m *MockRedisClusterClientInterface) Get(ctx context.Context, key string) *redis.StringCmd {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, key)
+	ret0, _ := ret[0].(*redis.StringCmd)
+	return ret0
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockRedisClusterClientInterfaceMockRecorder) Get(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).Get), ctx, key)
+}
+
+// SAdd mocks base method.
 func (m *MockRedisClusterClientInterface) SAdd(ctx context.Context, key string, members ...interface{}) *redis.IntCmd {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, key}
@@ -136,14 +109,14 @@ func (m *MockRedisClusterClientInterface) SAdd(ctx context.Context, key string, 
 	return ret0
 }
 
-// SAdd indicates an expected call of SAdd
+// SAdd indicates an expected call of SAdd.
 func (mr *MockRedisClusterClientInterfaceMockRecorder) SAdd(ctx, key interface{}, members ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, key}, members...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SAdd", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).SAdd), varargs...)
 }
 
-// SMembers mocks base method
+// SMembers mocks base method.
 func (m *MockRedisClusterClientInterface) SMembers(ctx context.Context, key string) *redis.StringSliceCmd {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SMembers", ctx, key)
@@ -151,8 +124,36 @@ func (m *MockRedisClusterClientInterface) SMembers(ctx context.Context, key stri
 	return ret0
 }
 
-// SMembers indicates an expected call of SMembers
+// SMembers indicates an expected call of SMembers.
 func (mr *MockRedisClusterClientInterfaceMockRecorder) SMembers(ctx, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SMembers", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).SMembers), ctx, key)
+}
+
+// Set mocks base method.
+func (m *MockRedisClusterClientInterface) Set(ctx context.Context, key string, values interface{}, expiration time.Duration) *redis.StatusCmd {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Set", ctx, key, values, expiration)
+	ret0, _ := ret[0].(*redis.StatusCmd)
+	return ret0
+}
+
+// Set indicates an expected call of Set.
+func (mr *MockRedisClusterClientInterfaceMockRecorder) Set(ctx, key, values, expiration interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).Set), ctx, key, values, expiration)
+}
+
+// TTL mocks base method.
+func (m *MockRedisClusterClientInterface) TTL(ctx context.Context, key string) *redis.DurationCmd {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TTL", ctx, key)
+	ret0, _ := ret[0].(*redis.DurationCmd)
+	return ret0
+}
+
+// TTL indicates an expected call of TTL.
+func (mr *MockRedisClusterClientInterfaceMockRecorder) TTL(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TTL", reflect.TypeOf((*MockRedisClusterClientInterface)(nil).TTL), ctx, key)
 }

--- a/test/mocks/store/clients/ristretto_interface.go
+++ b/test/mocks/store/clients/ristretto_interface.go
@@ -5,35 +5,60 @@
 package mocks
 
 import (
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockRistrettoClientInterface is a mock of RistrettoClientInterface interface
+// MockRistrettoClientInterface is a mock of RistrettoClientInterface interface.
 type MockRistrettoClientInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockRistrettoClientInterfaceMockRecorder
 }
 
-// MockRistrettoClientInterfaceMockRecorder is the mock recorder for MockRistrettoClientInterface
+// MockRistrettoClientInterfaceMockRecorder is the mock recorder for MockRistrettoClientInterface.
 type MockRistrettoClientInterfaceMockRecorder struct {
 	mock *MockRistrettoClientInterface
 }
 
-// NewMockRistrettoClientInterface creates a new mock instance
+// NewMockRistrettoClientInterface creates a new mock instance.
 func NewMockRistrettoClientInterface(ctrl *gomock.Controller) *MockRistrettoClientInterface {
 	mock := &MockRistrettoClientInterface{ctrl: ctrl}
 	mock.recorder = &MockRistrettoClientInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockRistrettoClientInterface) EXPECT() *MockRistrettoClientInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Clear mocks base method.
+func (m *MockRistrettoClientInterface) Clear() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Clear")
+}
+
+// Clear indicates an expected call of Clear.
+func (mr *MockRistrettoClientInterfaceMockRecorder) Clear() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockRistrettoClientInterface)(nil).Clear))
+}
+
+// Del mocks base method.
+func (m *MockRistrettoClientInterface) Del(key interface{}) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Del", key)
+}
+
+// Del indicates an expected call of Del.
+func (mr *MockRistrettoClientInterfaceMockRecorder) Del(key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockRistrettoClientInterface)(nil).Del), key)
+}
+
+// Get mocks base method.
 func (m *MockRistrettoClientInterface) Get(key interface{}) (interface{}, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", key)
@@ -42,13 +67,13 @@ func (m *MockRistrettoClientInterface) Get(key interface{}) (interface{}, bool) 
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockRistrettoClientInterfaceMockRecorder) Get(key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockRistrettoClientInterface)(nil).Get), key)
 }
 
-// SetWithTTL mocks base method
+// SetWithTTL mocks base method.
 func (m *MockRistrettoClientInterface) SetWithTTL(key, value interface{}, cost int64, ttl time.Duration) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetWithTTL", key, value, cost, ttl)
@@ -56,32 +81,8 @@ func (m *MockRistrettoClientInterface) SetWithTTL(key, value interface{}, cost i
 	return ret0
 }
 
-// SetWithTTL indicates an expected call of SetWithTTL
+// SetWithTTL indicates an expected call of SetWithTTL.
 func (mr *MockRistrettoClientInterfaceMockRecorder) SetWithTTL(key, value, cost, ttl interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWithTTL", reflect.TypeOf((*MockRistrettoClientInterface)(nil).SetWithTTL), key, value, cost, ttl)
-}
-
-// Del mocks base method
-func (m *MockRistrettoClientInterface) Del(key interface{}) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Del", key)
-}
-
-// Del indicates an expected call of Del
-func (mr *MockRistrettoClientInterfaceMockRecorder) Del(key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Del", reflect.TypeOf((*MockRistrettoClientInterface)(nil).Del), key)
-}
-
-// Clear mocks base method
-func (m *MockRistrettoClientInterface) Clear() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Clear")
-}
-
-// Clear indicates an expected call of Clear
-func (mr *MockRistrettoClientInterfaceMockRecorder) Clear() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockRistrettoClientInterface)(nil).Clear))
 }

--- a/test/mocks/store/store_interface.go
+++ b/test/mocks/store/store_interface.go
@@ -6,36 +6,65 @@ package mocks
 
 import (
 	context "context"
-	store "github.com/eko/gocache/v2/store"
-	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 	time "time"
+
+	store "github.com/eko/gocache/v2/store"
+	gomock "github.com/golang/mock/gomock"
 )
 
-// MockStoreInterface is a mock of StoreInterface interface
+// MockStoreInterface is a mock of StoreInterface interface.
 type MockStoreInterface struct {
 	ctrl     *gomock.Controller
 	recorder *MockStoreInterfaceMockRecorder
 }
 
-// MockStoreInterfaceMockRecorder is the mock recorder for MockStoreInterface
+// MockStoreInterfaceMockRecorder is the mock recorder for MockStoreInterface.
 type MockStoreInterfaceMockRecorder struct {
 	mock *MockStoreInterface
 }
 
-// NewMockStoreInterface creates a new mock instance
+// NewMockStoreInterface creates a new mock instance.
 func NewMockStoreInterface(ctrl *gomock.Controller) *MockStoreInterface {
 	mock := &MockStoreInterface{ctrl: ctrl}
 	mock.recorder = &MockStoreInterfaceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockStoreInterface) EXPECT() *MockStoreInterfaceMockRecorder {
 	return m.recorder
 }
 
-// Get mocks base method
+// Clear mocks base method.
+func (m *MockStoreInterface) Clear(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clear", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Clear indicates an expected call of Clear.
+func (mr *MockStoreInterfaceMockRecorder) Clear(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockStoreInterface)(nil).Clear), ctx)
+}
+
+// Delete mocks base method.
+func (m *MockStoreInterface) Delete(ctx context.Context, key interface{}) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, key)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockStoreInterfaceMockRecorder) Delete(ctx, key interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStoreInterface)(nil).Delete), ctx, key)
+}
+
+// Get mocks base method.
 func (m *MockStoreInterface) Get(ctx context.Context, key interface{}) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", ctx, key)
@@ -44,13 +73,27 @@ func (m *MockStoreInterface) Get(ctx context.Context, key interface{}) (interfac
 	return ret0, ret1
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockStoreInterfaceMockRecorder) Get(ctx, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockStoreInterface)(nil).Get), ctx, key)
 }
 
-// GetWithTTL mocks base method
+// GetType mocks base method.
+func (m *MockStoreInterface) GetType() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetType")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetType indicates an expected call of GetType.
+func (mr *MockStoreInterfaceMockRecorder) GetType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetType", reflect.TypeOf((*MockStoreInterface)(nil).GetType))
+}
+
+// GetWithTTL mocks base method.
 func (m *MockStoreInterface) GetWithTTL(ctx context.Context, key interface{}) (interface{}, time.Duration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWithTTL", ctx, key)
@@ -60,41 +103,13 @@ func (m *MockStoreInterface) GetWithTTL(ctx context.Context, key interface{}) (i
 	return ret0, ret1, ret2
 }
 
-// GetWithTTL indicates an expected call of GetWithTTL
+// GetWithTTL indicates an expected call of GetWithTTL.
 func (mr *MockStoreInterfaceMockRecorder) GetWithTTL(ctx, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWithTTL", reflect.TypeOf((*MockStoreInterface)(nil).GetWithTTL), ctx, key)
 }
 
-// Set mocks base method
-func (m *MockStoreInterface) Set(ctx context.Context, key, value interface{}, options *store.Options) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Set", ctx, key, value, options)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Set indicates an expected call of Set
-func (mr *MockStoreInterfaceMockRecorder) Set(ctx, key, value, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockStoreInterface)(nil).Set), ctx, key, value, options)
-}
-
-// Delete mocks base method
-func (m *MockStoreInterface) Delete(ctx context.Context, key interface{}) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, key)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete
-func (mr *MockStoreInterfaceMockRecorder) Delete(ctx, key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockStoreInterface)(nil).Delete), ctx, key)
-}
-
-// Invalidate mocks base method
+// Invalidate mocks base method.
 func (m *MockStoreInterface) Invalidate(ctx context.Context, options store.InvalidateOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Invalidate", ctx, options)
@@ -102,36 +117,22 @@ func (m *MockStoreInterface) Invalidate(ctx context.Context, options store.Inval
 	return ret0
 }
 
-// Invalidate indicates an expected call of Invalidate
+// Invalidate indicates an expected call of Invalidate.
 func (mr *MockStoreInterfaceMockRecorder) Invalidate(ctx, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Invalidate", reflect.TypeOf((*MockStoreInterface)(nil).Invalidate), ctx, options)
 }
 
-// Clear mocks base method
-func (m *MockStoreInterface) Clear(ctx context.Context) error {
+// Set mocks base method.
+func (m *MockStoreInterface) Set(ctx context.Context, key, value interface{}, options *store.Options) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Clear", ctx)
+	ret := m.ctrl.Call(m, "Set", ctx, key, value, options)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Clear indicates an expected call of Clear
-func (mr *MockStoreInterfaceMockRecorder) Clear(ctx interface{}) *gomock.Call {
+// Set indicates an expected call of Set.
+func (mr *MockStoreInterfaceMockRecorder) Set(ctx, key, value, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockStoreInterface)(nil).Clear), ctx)
-}
-
-// GetType mocks base method
-func (m *MockStoreInterface) GetType() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetType")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetType indicates an expected call of GetType
-func (mr *MockStoreInterfaceMockRecorder) GetType() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetType", reflect.TypeOf((*MockStoreInterface)(nil).GetType))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockStoreInterface)(nil).Set), ctx, key, value, options)
 }


### PR DESCRIPTION
Summary
- Updates memcached setTags method to use CompareAndSwap to update existing items to avoid overwriting other clients. And uses Add to create new tag keys.
- Adds Close method to LoadableCache to stop setter goroutine
