### PR TITLE
feat: Support for a key that would implement it's own key generator

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -16,6 +16,10 @@ const (
 	CacheType = "cache"
 )
 
+type CacheKeyGenerator interface {
+	GetCacheKey() string
+}
+
 // Cache represents the configuration needed by a cache
 type Cache struct {
 	codec codec.CodecInterface
@@ -79,6 +83,8 @@ func (c *Cache) getCacheKey(key interface{}) string {
 	switch key.(type) {
 	case string:
 		return key.(string)
+	case CacheKeyGenerator:
+		return key.(CacheKeyGenerator).GetCacheKey()
 	default:
 		return checksum(key)
 	}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -245,6 +245,28 @@ func TestCacheGetCacheKeyWhenKeyIsStruct(t *testing.T) {
 	assert.Equal(t, "8144fe5310cf0e62ac83fd79c113aad2", computedKey)
 }
 
+type StructWithGenerator struct{}
+
+func (_ *StructWithGenerator) GetCacheKey() string {
+	return "my-generated-key"
+}
+
+func TestCacheGetCacheKeyWhenKeyImplementsGenerator(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	store := mocksStore.NewMockStoreInterface(ctrl)
+
+	cache := New(store)
+
+	// When
+	key := &StructWithGenerator{}
+
+	generatedKey := cache.getCacheKey(key)
+	// Then
+	assert.Equal(t, "my-generated-key", generatedKey)
+}
+
 func TestCacheDelete(t *testing.T) {
 	// Given
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
*Feature request*
Especially when using the LoadableCache, you would typically provide the arguments of the loadFunc as a key and inside the cache the key would be generated as the md5 checksum of the type and value when the key is not already a string. I would like the keys to be human readable and thus implement my owner type to string conversion.

With this PR the user is able to implent it's own `GetCacheKey()` function when required. The only BC break I see is when an existing user already implemented this function and wasn't expeciting it to be used by the cache to generate the cache key.