### PR TITLE
Make setTags method concurrency-safe

### DIFF
--- a/store/go_cache.go
+++ b/store/go_cache.go
@@ -132,9 +132,11 @@ func (s *GoCacheStore) Invalidate(ctx context.Context, options InvalidateOptions
 				cacheKeys = bytes
 			}
 
+			s.mu.RLock()
 			for cacheKey := range cacheKeys {
 				_ = s.Delete(ctx, cacheKey)
 			}
+			s.mu.RUnlock()
 		}
 	}
 


### PR DESCRIPTION
Concurrency issues are hard to catch, but the tests that I've written fail in the exact right way at my computer.

This change is already tested in concurrent environment, works safely.