### PR TITLE
Update chain Set() to attempt to set to in each cache even if one fails

### DIFF
--- a/cache/chain.go
+++ b/cache/chain.go
@@ -72,12 +72,20 @@ func (c *ChainCache) Get(ctx context.Context, key interface{}) (interface{}, err
 
 // Set sets a value in available caches
 func (c *ChainCache) Set(ctx context.Context, key, object interface{}, options *store.Options) error {
+	errs := []error{}
 	for _, cache := range c.caches {
 		err := cache.Set(ctx, key, object, options)
 		if err != nil {
 			storeType := cache.GetCodec().GetStore().GetType()
-			return fmt.Errorf("Unable to set item into cache with store '%s': %v", storeType, err)
+			errs = append(errs, fmt.Errorf("Unable to set item into cache with store '%s': %v", storeType, err))
 		}
+	}
+	if len(errs) > 0 {
+		errStr := ""
+		for k, v := range errs {
+			errStr += fmt.Sprintf("Error %d of %d: %v", k, len(errs), v.Error())
+		}
+		return errors.New(errStr)
 	}
 
 	return nil

--- a/cache/chain.go
+++ b/cache/chain.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -83,7 +84,7 @@ func (c *ChainCache) Set(ctx context.Context, key, object interface{}, options *
 	if len(errs) > 0 {
 		errStr := ""
 		for k, v := range errs {
-			errStr += fmt.Sprintf("Error %d of %d: %v", k, len(errs), v.Error())
+			errStr += fmt.Sprintf("error %d of %d: %v", k+1, len(errs), v.Error())
 		}
 		return errors.New(errStr)
 	}

--- a/cache/chain_test.go
+++ b/cache/chain_test.go
@@ -434,3 +434,37 @@ func TestCacheChecksum(t *testing.T) {
 		assert.Equal(t, tc.expectedHash, value)
 	}
 }
+
+func TestChainSetWhenErrorInChain(t *testing.T) {
+
+	// Given
+	ctrl := gomock.NewController(t)
+	store1 := mocksCache.NewMockSetterCacheInterface(ctrl)
+
+	store1.EXPECT().GetType().AnyTimes().Return("store1")
+	codec1 := mocksCodec.NewMockCodecInterface(ctrl)
+	codec1.EXPECT().GetStore().AnyTimes().Return(store1)
+	store1.EXPECT().GetCodec().AnyTimes().Return(codec1)
+
+	ctx := context.Background()
+	key := "test-key"
+	value := "test-value"
+	interError := errors.New("An issue occurred with the cache")
+	store1.EXPECT().Set(ctx, key, value, nil).DoAndReturn(func(_, _, _, _ interface{}) error {
+		return interError
+	})
+
+	store2 := mocksCache.NewMockSetterCacheInterface(ctrl)
+
+	cache := NewChain(store1, store2)
+
+	// assert store2 set is called
+	store2.EXPECT().Set(ctx, key, value, nil).Return(nil)
+
+	// When - Then
+	err := cache.Set(ctx, key, value, nil)
+
+	expErr := errors.New("error 1 of 1: Unable to set item into cache with store 'store1': An issue occurred with the cache")
+	// Then
+	assert.Equal(t, expErr, err)
+}

--- a/store/bigcache.go
+++ b/store/bigcache.go
@@ -48,7 +48,7 @@ func (s *BigcacheStore) Get(_ context.Context, key interface{}) (interface{}, er
 		return nil, err
 	}
 	if item == nil {
-		return nil, errors.New("Unable to retrieve data from bigcache")
+		return nil, NotFoundWithCause(errors.New("Unable to retrieve data from bigcache"))
 	}
 
 	return item, err

--- a/store/errors.go
+++ b/store/errors.go
@@ -1,0 +1,26 @@
+package store
+
+const NOT_FOUND_ERR string = "Value not found in store"
+
+type NotFound struct {
+	cause error
+}
+
+func NotFoundWithCause(e error) error {
+	return NotFound{
+		cause: e,
+	}
+}
+
+func (e NotFound) Cause() error {
+	return e.cause
+}
+
+func (e NotFound) Is(err error) bool {
+	return err.Error() == NOT_FOUND_ERR
+}
+
+func (e NotFound) Error() string {
+	return NOT_FOUND_ERR
+}
+func (e NotFound) Unwrap() error { return e.cause }

--- a/store/errors_test.go
+++ b/store/errors_test.go
@@ -1,0 +1,19 @@
+package store
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNotFoundIs(t *testing.T) {
+
+	err := NotFoundWithCause(redis.Nil)
+	assert.True(t, errors.Is(err, NotFound{}))
+	assert.True(t, errors.Is(err, redis.Nil))
+
+	err = NotFound{}
+	assert.True(t, errors.Is(err, NotFound{}))
+}

--- a/store/freecache.go
+++ b/store/freecache.go
@@ -52,7 +52,7 @@ func (f *FreecacheStore) Get(_ context.Context, key interface{}) (interface{}, e
 	if k, ok := key.(string); ok {
 		result, err = f.client.Get([]byte(k))
 		if err != nil {
-			return nil, errors.New("value not found in Freecache store")
+			return nil, NotFoundWithCause(errors.New("value not found in Freecache store"))
 		}
 		return result, err
 	}
@@ -65,12 +65,12 @@ func (f *FreecacheStore) GetWithTTL(_ context.Context, key interface{}) (interfa
 	if k, ok := key.(string); ok {
 		result, err := f.client.Get([]byte(k))
 		if err != nil {
-			return nil, 0, errors.New("value not found in Freecache store")
+			return nil, 0, NotFoundWithCause(errors.New("value not found in Freecache store"))
 		}
 
 		ttl, err := f.client.TTL([]byte(k))
 		if err != nil {
-			return nil, 0, errors.New("value not found in Freecache store")
+			return nil, 0, NotFoundWithCause(errors.New("value not found in Freecache store"))
 		}
 
 		return result, time.Duration(ttl) * time.Second, err

--- a/store/go_cache.go
+++ b/store/go_cache.go
@@ -49,7 +49,7 @@ func (s *GoCacheStore) Get(_ context.Context, key interface{}) (interface{}, err
 	keyStr := key.(string)
 	value, exists := s.client.Get(keyStr)
 	if !exists {
-		err = errors.New("Value not found in GoCache store")
+		err = NotFoundWithCause(errors.New("Value not found in GoCache store"))
 	}
 
 	return value, err
@@ -59,7 +59,7 @@ func (s *GoCacheStore) Get(_ context.Context, key interface{}) (interface{}, err
 func (s *GoCacheStore) GetWithTTL(_ context.Context, key interface{}) (interface{}, time.Duration, error) {
 	data, t, exists := s.client.GetWithExpiration(key.(string))
 	if !exists {
-		return data, 0, errors.New("Value not found in GoCache store")
+		return data, 0, NotFoundWithCause(errors.New("Value not found in GoCache store"))
 	}
 	duration := t.Sub(time.Now())
 	return data, duration, nil

--- a/store/memcache.go
+++ b/store/memcache.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"strings"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/bradfitz/gomemcache/memcache"
 )
@@ -55,7 +56,7 @@ func (s *MemcacheStore) Get(_ context.Context, key interface{}) (interface{}, er
 		return nil, err
 	}
 	if item == nil {
-		return nil, errors.New("Unable to retrieve data from memcache")
+		return nil, NotFoundWithCause(errors.New("Unable to retrieve data from memcache"))
 	}
 
 	return item.Value, err
@@ -68,7 +69,7 @@ func (s *MemcacheStore) GetWithTTL(_ context.Context, key interface{}) (interfac
 		return nil, 0, err
 	}
 	if item == nil {
-		return nil, 0, errors.New("Unable to retrieve data from memcache")
+		return nil, 0, NotFoundWithCause(errors.New("Unable to retrieve data from memcache"))
 	}
 
 	return item.Value, time.Duration(item.Expiration) * time.Second, err

--- a/store/pegasus.go
+++ b/store/pegasus.go
@@ -139,7 +139,9 @@ func (p *PegasusStore) Get(ctx context.Context, key interface{}) (interface{}, e
 	if err != nil {
 		return nil, err
 	}
-
+	if value == nil {
+		return nil, NotFound{}
+	}
 	return value, nil
 }
 
@@ -154,6 +156,9 @@ func (p *PegasusStore) GetWithTTL(ctx context.Context, key interface{}) (interfa
 	value, err := table.Get(ctx, []byte(cast.ToString(key)), empty)
 	if err != nil {
 		return nil, 0, err
+	}
+	if value == nil {
+		return nil, 0, NotFound{}
 	}
 
 	ttl, err := table.TTL(ctx, []byte(cast.ToString(key)), empty)

--- a/store/redis.go
+++ b/store/redis.go
@@ -47,12 +47,19 @@ func NewRedis(client RedisClientInterface, options *Options) *RedisStore {
 
 // Get returns data stored from a given key
 func (s *RedisStore) Get(ctx context.Context, key interface{}) (interface{}, error) {
-	return s.client.Get(ctx, key.(string)).Result()
+	object, err := s.client.Get(ctx, key.(string)).Result()
+	if err == redis.Nil {
+		return nil, NotFoundWithCause(err)
+	}
+	return object, err
 }
 
 // GetWithTTL returns data stored from a given key and its corresponding TTL
 func (s *RedisStore) GetWithTTL(ctx context.Context, key interface{}) (interface{}, time.Duration, error) {
 	object, err := s.client.Get(ctx, key.(string)).Result()
+	if err == redis.Nil {
+		return nil, 0, NotFoundWithCause(err)
+	}
 	if err != nil {
 		return nil, 0, err
 	}

--- a/store/rediscluster.go
+++ b/store/rediscluster.go
@@ -47,12 +47,19 @@ func NewRedisCluster(client RedisClusterClientInterface, options *Options) *Redi
 
 // Get returns data stored from a given key
 func (s *RedisClusterStore) Get(ctx context.Context, key interface{}) (interface{}, error) {
-	return s.clusclient.Get(ctx, key.(string)).Result()
+	object, err := s.clusclient.Get(ctx, key.(string)).Result()
+	if err == redis.Nil {
+		return nil, NotFoundWithCause(err)
+	}
+	return object, err
 }
 
 // GetWithTTL returns data stored from a given key and its corresponding TTL
 func (s *RedisClusterStore) GetWithTTL(ctx context.Context, key interface{}) (interface{}, time.Duration, error) {
 	object, err := s.clusclient.Get(ctx, key.(string)).Result()
+	if err == redis.Nil {
+		return nil, 0, NotFoundWithCause(err)
+	}
 	if err != nil {
 		return nil, 0, err
 	}

--- a/store/ristretto.go
+++ b/store/ristretto.go
@@ -47,7 +47,7 @@ func (s *RistrettoStore) Get(_ context.Context, key interface{}) (interface{}, e
 
 	value, exists := s.client.Get(key)
 	if !exists {
-		err = errors.New("Value not found in Ristretto store")
+		err = NotFoundWithCause(errors.New("Value not found in Ristretto store"))
 	}
 
 	return value, err


### PR DESCRIPTION
Instead of returning when one cache fails this update attempts to set the value for each cache and then returns an aggregate error if one or more fail. This allows the user to run the cache in a fallback mode. 