### PR TITLE
Delete cache item containing cache keys for a tag upon tag invalidation

### DIFF
--- a/store/bigcache.go
+++ b/store/bigcache.go
@@ -140,6 +140,7 @@ func (s *BigcacheStore) Invalidate(ctx context.Context, options InvalidateOption
 			for _, cacheKey := range cacheKeys {
 				s.Delete(ctx, cacheKey)
 			}
+			s.Delete(ctx, tagKey)
 		}
 	}
 

--- a/store/bigcache_test.go
+++ b/store/bigcache_test.go
@@ -295,6 +295,7 @@ func TestBigcacheInvalidate(t *testing.T) {
 	client.EXPECT().Get("gocache_tag_tag1").Return(cacheKeys, nil)
 	client.EXPECT().Delete("a23fdf987h2svc23").Return(nil)
 	client.EXPECT().Delete("jHG2372x38hf74").Return(nil)
+	client.EXPECT().Delete("gocache_tag_tag1").Return(nil)
 
 	store := NewBigcache(client, nil)
 
@@ -321,6 +322,7 @@ func TestBigcacheInvalidateWhenError(t *testing.T) {
 	client.EXPECT().Get("gocache_tag_tag1").Return(cacheKeys, nil)
 	client.EXPECT().Delete("a23fdf987h2svc23").Return(errors.New("Unexpected error"))
 	client.EXPECT().Delete("jHG2372x38hf74").Return(nil)
+	client.EXPECT().Delete("gocache_tag_tag1").Return(nil)
 
 	store := NewBigcache(client, nil)
 

--- a/store/go_cache.go
+++ b/store/go_cache.go
@@ -132,11 +132,12 @@ func (s *GoCacheStore) Invalidate(ctx context.Context, options InvalidateOptions
 				cacheKeys = bytes
 			}
 
-			s.mu.RLock()
+			s.mu.Lock()
 			for cacheKey := range cacheKeys {
 				_ = s.Delete(ctx, cacheKey)
 			}
-			s.mu.RUnlock()
+			_ = s.Delete(ctx, tagKey)
+			s.mu.Unlock()
 		}
 	}
 

--- a/store/go_cache_test.go
+++ b/store/go_cache_test.go
@@ -249,6 +249,7 @@ func TestGoCacheInvalidate(t *testing.T) {
 	client.EXPECT().Get("gocache_tag_tag1").Return(cacheKeys, true)
 	client.EXPECT().Delete("a23fdf987h2svc23")
 	client.EXPECT().Delete("jHG2372x38hf74")
+	client.EXPECT().Delete("gocache_tag_tag1")
 
 	store := NewGoCache(client, nil)
 

--- a/store/memcache.go
+++ b/store/memcache.go
@@ -184,6 +184,7 @@ func (s *MemcacheStore) Invalidate(ctx context.Context, options InvalidateOption
 			for _, cacheKey := range cacheKeys {
 				s.Delete(ctx, cacheKey)
 			}
+			s.Delete(ctx, tagKey)
 		}
 	}
 

--- a/store/memcache_test.go
+++ b/store/memcache_test.go
@@ -354,6 +354,7 @@ func TestMemcacheInvalidate(t *testing.T) {
 	client.EXPECT().Get("gocache_tag_tag1").Return(cacheKeys, nil)
 	client.EXPECT().Delete("a23fdf987h2svc23").Return(nil)
 	client.EXPECT().Delete("jHG2372x38hf74").Return(nil)
+	client.EXPECT().Delete("gocache_tag_tag1").Return(nil)
 
 	store := NewMemcache(client, nil)
 
@@ -382,6 +383,7 @@ func TestMemcacheInvalidateWhenError(t *testing.T) {
 	client.EXPECT().Get("gocache_tag_tag1").Return(cacheKeys, nil)
 	client.EXPECT().Delete("a23fdf987h2svc23").Return(errors.New("Unexpected error"))
 	client.EXPECT().Delete("jHG2372x38hf74").Return(nil)
+	client.EXPECT().Delete("gocache_tag_tag1").Return(nil)
 
 	store := NewMemcache(client, nil)
 

--- a/store/pegasus.go
+++ b/store/pegasus.go
@@ -253,6 +253,9 @@ func (p *PegasusStore) Invalidate(ctx context.Context, options InvalidateOptions
 					return err
 				}
 			}
+			if err := p.Delete(ctx, tagKey); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/store/ristretto.go
+++ b/store/ristretto.go
@@ -135,6 +135,7 @@ func (s *RistrettoStore) Invalidate(ctx context.Context, options InvalidateOptio
 			for _, cacheKey := range cacheKeys {
 				s.Delete(ctx, cacheKey)
 			}
+			s.Delete(ctx, tagKey)
 		}
 	}
 

--- a/store/ristretto_test.go
+++ b/store/ristretto_test.go
@@ -274,6 +274,7 @@ func TestRistrettoInvalidate(t *testing.T) {
 	client.EXPECT().Get("gocache_tag_tag1").Return(cacheKeys, true)
 	client.EXPECT().Del("a23fdf987h2svc23")
 	client.EXPECT().Del("jHG2372x38hf74")
+	client.EXPECT().Del("gocache_tag_tag1")
 
 	store := NewRistretto(client, nil)
 


### PR DESCRIPTION
@eko what do you think, should we delete the collection of cache keys after each of the keys was deleted?