### PR TITLE
Fix for applyOptionsWithDefault not keeping unmodified options

### DIFF
--- a/store/options.go
+++ b/store/options.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// Options represents a store option function.
+// Option represents a store option function.
 type Option func(o *Options)
 
 type Options struct {
@@ -18,10 +18,11 @@ func (o *Options) isEmpty() bool {
 }
 
 func applyOptionsWithDefault(defaultOptions *Options, opts ...Option) *Options {
-	returnedOptions := applyOptions(opts...)
+	returnedOptions := &Options{}
+	*returnedOptions = *defaultOptions
 
-	if returnedOptions.isEmpty() {
-		returnedOptions = defaultOptions
+	for _, opt := range opts {
+		opt(returnedOptions)
 	}
 
 	return returnedOptions

--- a/store/options_test.go
+++ b/store/options_test.go
@@ -36,3 +36,17 @@ func TestOptionsTagsValue(t *testing.T) {
 	// When - Then
 	assert.Equal(t, []string{"tag1", "tag2", "tag3"}, options.tags)
 }
+
+func Test_applyOptionsWithDefault(t *testing.T) {
+	// Given
+	defaultOptions := &Options{
+		expiration: 25 * time.Second,
+	}
+
+	// When
+	options := applyOptionsWithDefault(defaultOptions, WithCost(7))
+
+	// Then
+	assert.Equal(t, int64(7), options.cost)
+	assert.Equal(t, 25*time.Second, options.expiration)
+}


### PR DESCRIPTION
I assume this was just an oversight. I was expecting that any specified options would override defaults, but unspecified options would still use the default options.

IE:

```go
// Given
defaultOptions := &Options{
	expiration: 25 * time.Second,
}

// When
options := applyOptionsWithDefault(defaultOptions, WithCost(7))

// Then
assert.Equal(t, int64(7), options.cost)
assert.Equal(t, 25*time.Second, options.expiration)
```