### PR TITLE
Fixing Rueidis store implementation

### DIFF
--- a/lib/store/options.go
+++ b/lib/store/options.go
@@ -8,9 +8,10 @@ import (
 type Option func(o *Options)
 
 type Options struct {
-	Cost       int64
-	Expiration time.Duration
-	Tags       []string
+	Cost                      int64
+	Expiration                time.Duration
+	Tags                      []string
+	ClientSideCacheExpiration time.Duration
 }
 
 func (o *Options) IsEmpty() bool {
@@ -57,5 +58,13 @@ func WithExpiration(expiration time.Duration) Option {
 func WithTags(tags []string) Option {
 	return func(o *Options) {
 		o.Tags = tags
+	}
+}
+
+// WithClientSideCaching allows setting the client side caching, enabled by default
+// Currently to be used by Rueidis(redis) library only.
+func WithClientSideCaching(clientSideCacheExpiration time.Duration) Option {
+	return func(o *Options) {
+		o.ClientSideCacheExpiration = clientSideCacheExpiration
 	}
 }

--- a/store/rueidis/rueidis.go
+++ b/store/rueidis/rueidis.go
@@ -16,7 +16,7 @@ const (
 	// RueidisTagPattern represents the tag pattern to be used as a key in specified storage
 	RueidisTagPattern = "gocache_tag_%s"
 
-	defaultExpiration = 10 * time.Second
+	defaultClientSideCacheExpiration = 10 * time.Second
 )
 
 // RueidisStore is a store for Redis
@@ -29,16 +29,16 @@ type RueidisStore struct {
 
 // NewRueidis creates a new store to Redis instance(s)
 func NewRueidis(client rueidis.Client, options ...lib_store.Option) *RueidisStore {
-	// defaults client expiration to 10s
+	// defaults client side cache expiration to 10s
 	appliedOptions := lib_store.ApplyOptions(options...)
 
-	if appliedOptions.Expiration == 0 {
-		appliedOptions.Expiration = defaultExpiration
+	if appliedOptions.ClientSideCacheExpiration == 0 {
+		appliedOptions.ClientSideCacheExpiration = defaultClientSideCacheExpiration
 	}
 
 	return &RueidisStore{
 		client:      client,
-		cacheCompat: rueidiscompat.NewAdapter(client).Cache(appliedOptions.Expiration),
+		cacheCompat: rueidiscompat.NewAdapter(client).Cache(appliedOptions.ClientSideCacheExpiration),
 		compat:      rueidiscompat.NewAdapter(client),
 		options:     appliedOptions,
 	}
@@ -46,7 +46,7 @@ func NewRueidis(client rueidis.Client, options ...lib_store.Option) *RueidisStor
 
 // Get returns data stored from a given key
 func (s *RueidisStore) Get(ctx context.Context, key any) (any, error) {
-	object := s.client.DoCache(ctx, s.client.B().Get().Key(key.(string)).Cache(), s.options.Expiration)
+	object := s.client.DoCache(ctx, s.client.B().Get().Key(key.(string)).Cache(), s.options.ClientSideCacheExpiration)
 	if object.RedisError() != nil && object.RedisError().IsNil() {
 		return nil, lib_store.NotFoundWithCause(object.Error())
 	}

--- a/store/rueidis/rueidis_bench_test.go
+++ b/store/rueidis/rueidis_bench_test.go
@@ -22,7 +22,7 @@ func BenchmarkRueidisSet(b *testing.B) {
 		SelectDB: 0,
 	})
 
-	store := NewRueidis(ruedisClient, nil, lib_store.WithExpiration(time.Hour*4))
+	store := NewRueidis(ruedisClient, lib_store.WithExpiration(time.Hour*4))
 
 	for k := 0.; k <= 10; k++ {
 		n := int(math.Pow(2, k))
@@ -48,7 +48,7 @@ func BenchmarkRueidisGet(b *testing.B) {
 		SelectDB: 0,
 	})
 
-	store := NewRueidis(ruedisClient, nil, lib_store.WithExpiration(time.Hour*4))
+	store := NewRueidis(ruedisClient, lib_store.WithExpiration(time.Hour*4))
 
 	key := "test"
 	value := []byte("value")


### PR DESCRIPTION
Hey @eko , thanks for doing that and sorry for taking so long to include the tests.
I'm adding a new test for NotFound, just to ensure it is working as intended. Also, fixing the idea of the `clientExpiration` option I've done in the previous proposal. The idea here is to keep the `expiration` using TTL (server-side), but give an option to the user to use a different expiration time for the server-assisted client cache (more info on the link below).

### Commit notes:
Adding [ClientSideCacheExpiration](https://github.com/rueian/rueidis#client-side-caching) option for [rueidis](https://github.com/rueian/rueidis), tweaking tests and benchmarks.

### Benchmark Results:

```
goos: linux
goarch: amd64
pkg: github.com/eko/gocache/v4/store/rueidis
cpu: AMD Ryzen 5 1600 Six-Core Processor            
BenchmarkRueidisSet
BenchmarkRueidisSet/1
BenchmarkRueidisSet/1-12  	    6164	    243191 ns/op
BenchmarkRueidisSet/2
BenchmarkRueidisSet/2-12  	    3741	    463155 ns/op
BenchmarkRueidisSet/4
BenchmarkRueidisSet/4-12  	    1765	    719615 ns/op
BenchmarkRueidisSet/8
BenchmarkRueidisSet/8-12  	     897	   1371644 ns/op
BenchmarkRueidisSet/16
BenchmarkRueidisSet/16-12 	     397	   4154892 ns/op
BenchmarkRueidisSet/32
BenchmarkRueidisSet/32-12 	     224	   6195236 ns/op
BenchmarkRueidisSet/64
BenchmarkRueidisSet/64-12 	     100	  13440387 ns/op
BenchmarkRueidisSet/128
BenchmarkRueidisSet/128-12         	      38	  26693594 ns/op
BenchmarkRueidisSet/256
BenchmarkRueidisSet/256-12         	      16	  64581190 ns/op
BenchmarkRueidisSet/512
BenchmarkRueidisSet/512-12         	      10	 113861449 ns/op
BenchmarkRueidisSet/1024
BenchmarkRueidisSet/1024-12        	       5	 208020637 ns/op
BenchmarkRueidisGet
BenchmarkRueidisGet/1
BenchmarkRueidisGet/1-12           	 2415909	       620.8 ns/op
BenchmarkRueidisGet/2
BenchmarkRueidisGet/2-12           	 1023564	      1205 ns/op
BenchmarkRueidisGet/4
BenchmarkRueidisGet/4-12           	  499236	      2372 ns/op
BenchmarkRueidisGet/8
BenchmarkRueidisGet/8-12           	  270166	      4725 ns/op
BenchmarkRueidisGet/16
BenchmarkRueidisGet/16-12          	  112500	      9645 ns/op
BenchmarkRueidisGet/32
BenchmarkRueidisGet/32-12          	   56277	     18923 ns/op
BenchmarkRueidisGet/64
BenchmarkRueidisGet/64-12          	   30972	     42437 ns/op
BenchmarkRueidisGet/128
BenchmarkRueidisGet/128-12         	   16580	     77926 ns/op
BenchmarkRueidisGet/256
BenchmarkRueidisGet/256-12         	    6326	    168652 ns/op
BenchmarkRueidisGet/512
BenchmarkRueidisGet/512-12         	    3812	    319607 ns/op
BenchmarkRueidisGet/1024
BenchmarkRueidisGet/1024-12        	    2150	    624327 ns/op
PASS
```