### PR TITLE
Mark bigcache GetWithTTL as not implemented

### DIFF
--- a/store/bigcache/bigcache.go
+++ b/store/bigcache/bigcache.go
@@ -52,10 +52,9 @@ func (s *BigcacheStore) Get(_ context.Context, key any) (any, error) {
 	return item, err
 }
 
-// GetWithTTL returns data stored from a given key and its corresponding TTL
+// Not implemented for BigcacheStore
 func (s *BigcacheStore) GetWithTTL(ctx context.Context, key any) (any, time.Duration, error) {
-	item, err := s.Get(ctx, key)
-	return item, 0, err
+	return nil, 0, errors.New("method not implemented for codec, use Get() instead")
 }
 
 // Set defines data in Bigcache for given key identifier

--- a/store/bigcache/bigcache_test.go
+++ b/store/bigcache/bigcache_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	lib_store "github.com/eko/gocache/lib/v4/store"
 	"github.com/golang/mock/gomock"
@@ -78,44 +77,17 @@ func TestBigcacheGetWithTTL(t *testing.T) {
 	ctx := context.Background()
 
 	cacheKey := "my-key"
-	cacheValue := []byte("my-cache-value")
-
 	client := NewMockBigcacheClientInterface(ctrl)
-	client.EXPECT().Get(cacheKey).Return(cacheValue, nil)
-
 	store := NewBigcache(client)
 
-	// When
-	value, ttl, err := store.GetWithTTL(ctx, cacheKey)
-
-	// Then
-	assert.Nil(t, err)
-	assert.Equal(t, cacheValue, value)
-	assert.Equal(t, 0*time.Second, ttl)
-}
-
-func TestBigcacheGetWithTTLWhenError(t *testing.T) {
-	// Given
-	ctrl := gomock.NewController(t)
-
-	ctx := context.Background()
-
-	cacheKey := "my-key"
-
-	expectedErr := errors.New("an unexpected error occurred")
-
-	client := NewMockBigcacheClientInterface(ctrl)
-	client.EXPECT().Get(cacheKey).Return(nil, expectedErr)
-
-	store := NewBigcache(client)
+	expectedErr := errors.New("method not implemented for codec, use Get() instead")
 
 	// When
-	value, ttl, err := store.GetWithTTL(ctx, cacheKey)
+	value, _, err := store.GetWithTTL(ctx, cacheKey)
 
 	// Then
 	assert.Equal(t, expectedErr, err)
 	assert.Nil(t, value)
-	assert.Equal(t, 0*time.Second, ttl)
 }
 
 func TestBigcacheSet(t *testing.T) {


### PR DESCRIPTION
Problem and solution presented in issue #172.

The bigcache implementation of GetWithTTL is just a hard coded 0 duration but with no indication in API it will not work as intended.

I suggest instead returning an error that lets the user know that the method is in fact not supported and it should not be relied upon.