### PR TITLE
Hazelcast store refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ redisStore := redis_store.NewRedis(redis.NewClient(&redis.Options{
 }))
 
 cacheManager := cache.New[string](redisStore)
-err := cacheManager.Set("my-key", "my-value", store.WithExpiration(15*time.Second))
+err := cacheManager.Set(ctx, "my-key", "my-value", store.WithExpiration(15*time.Second))
 if err != nil {
     panic(err)
 }
@@ -247,20 +247,17 @@ value, _ := cacheManager.Get(ctx, "my-key")
 #### Hazelcast
 
 ```go
-client, err := hazelcast.StartNewClient(ctx)
+hzClient, err := hazelcast.StartNewClient(ctx)
 if err != nil {
     log.Fatalf("Failed to start client: %v", err)
 }
 
-hzMap, err := client.GetMap(ctx, "gocache")
-if err != nil {
-    log.Fatalf("Failed to get map: %v", err)
-}
+hzMapName:= "gocache"
 
-hazelcastStore := hazelcast_store.NewHazelcast(hzMap)
+hazelcastStore := hazelcast_store.NewHazelcast(hzClient, hzMapName)
 
 cacheManager := cache.New[string](hazelcastStore)
-err := cacheManager.Set("my-key", "my-value", store.WithExpiration(15*time.Second))
+err := cacheManager.Set(ctx, "my-key", "my-value", store.WithExpiration(15*time.Second))
 if err != nil {
     panic(err)
 }

--- a/store/hazelcast/hazelcast_benchmark_test.go
+++ b/store/hazelcast/hazelcast_benchmark_test.go
@@ -13,17 +13,12 @@ import (
 func BenchmarkHazelcastSet(b *testing.B) {
 	ctx := context.Background()
 
-	client, err := hazelcast.StartNewClient(ctx)
+	hzClient, err := hazelcast.StartNewClient(ctx)
 	if err != nil {
 		b.Fatalf("Failed to start client: %v", err)
 	}
 
-	hzMap, err := client.GetMap(ctx, "gocache")
-	if err != nil {
-		b.Fatalf("Failed to get map: %v", err)
-	}
-
-	store := NewHazelcast(hzMap)
+	store := NewHazelcast(hzClient, "gocache")
 
 	for k := 0.; k <= 10; k++ {
 		n := int(math.Pow(2, k))
@@ -40,17 +35,12 @@ func BenchmarkHazelcastSet(b *testing.B) {
 func BenchmarkHazelcastGet(b *testing.B) {
 	ctx := context.Background()
 
-	client, err := hazelcast.StartNewClient(ctx)
+	hzClient, err := hazelcast.StartNewClient(ctx)
 	if err != nil {
 		b.Fatalf("Failed to start client: %v", err)
 	}
 
-	hzMap, err := client.GetMap(ctx, "gocache")
-	if err != nil {
-		b.Fatalf("Failed to get map: %v", err)
-	}
-
-	store := NewHazelcast(hzMap)
+	store := NewHazelcast(hzClient, "gocache")
 
 	key := "test"
 	value := []byte("value")


### PR DESCRIPTION
It is better to have `HazelcastMapInterfaceProvider` in order to get a new map instance every time when it is needed.