### PR TITLE
docs(readme): remove redundant generic import

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,6 @@ package main
 
 import (
 	"log"
-	"github.com/eko/gocache/lib/v4/generic"
 	"github.com/eko/gocache/lib/v4/cache"
 	"github.com/eko/gocache/lib/v4/store"
 )


### PR DESCRIPTION
The `"github.com/eko/gocache/lib/v4/generic"` import is redundant.