### PR TITLE
update ruedis dependency to reflect changes

### DIFF
--- a/store/rueidis/go.mod
+++ b/store/rueidis/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/eko/gocache/lib/v4 v4.1.3
 	github.com/golang/mock v1.6.0
-	github.com/rueian/rueidis v0.0.95
+	github.com/redis/rueidis v0.0.95
 	github.com/stretchr/testify v1.8.1
 )
 

--- a/store/rueidis/go.mod
+++ b/store/rueidis/go.mod
@@ -1,4 +1,4 @@
-module github.com/eko/gocache/store/rueidis/v4
+module github.com/wexder/gocache/store/rueidis/v4
 
 go 1.19
 


### PR DESCRIPTION
Fixes changes to the rueidis dependency which switched repository path  to github.com/redis/rueidis