### PR TITLE
[Ristretto Store] Add configurable synchronous write option

### DIFF
--- a/lib/store/options.go
+++ b/lib/store/options.go
@@ -8,6 +8,7 @@ import (
 type Option func(o *Options)
 
 type Options struct {
+	SynchronousSet            bool
 	Cost                      int64
 	Expiration                time.Duration
 	Tags                      []string
@@ -44,6 +45,14 @@ func ApplyOptions(opts ...Option) *Options {
 func WithCost(cost int64) Option {
 	return func(o *Options) {
 		o.Cost = cost
+	}
+}
+
+// WithSynchronousSet allows setting the behavior when setting a value, whether to wait until all buffered writes have been applied or not.
+// Currently to be used by Ristretto library only.
+func WithSynchronousSet() Option {
+	return func(o *Options) {
+		o.SynchronousSet = true
 	}
 }
 

--- a/store/ristretto/ristretto.go
+++ b/store/ristretto/ristretto.go
@@ -23,6 +23,7 @@ type RistrettoClientInterface interface {
 	SetWithTTL(key, value any, cost int64, ttl time.Duration) bool
 	Del(key any)
 	Clear()
+	Wait()
 }
 
 // RistrettoStore is a store for Ristretto (memory) library
@@ -69,6 +70,10 @@ func (s *RistrettoStore) Set(ctx context.Context, key any, value any, options ..
 
 	if err != nil {
 		return err
+	}
+
+	if opts.SynchronousSet {
+		s.client.Wait()
 	}
 
 	if tags := opts.Tags; len(tags) > 0 {

--- a/store/ristretto/ristretto_bench_test.go
+++ b/store/ristretto/ristretto_bench_test.go
@@ -21,7 +21,33 @@ func BenchmarkRistrettoSet(b *testing.B) {
 	if err != nil {
 		panic(err)
 	}
-	store := NewRistretto(client, nil)
+	store := NewRistretto(client)
+
+	for k := 0.; k <= 10; k++ {
+		n := int(math.Pow(2, k))
+		b.Run(fmt.Sprintf("%d", n), func(b *testing.B) {
+			for i := 0; i < b.N*n; i++ {
+				key := fmt.Sprintf("test-%d", n)
+				value := []byte(fmt.Sprintf("value-%d", n))
+
+				store.Set(ctx, key, value, lib_store.WithTags([]string{fmt.Sprintf("tag-%d", n)}))
+			}
+		})
+	}
+}
+
+func BenchmarkRistrettoSetWithSynchronousSet(b *testing.B) {
+	ctx := context.Background()
+
+	client, err := ristretto.NewCache(&ristretto.Config{
+		NumCounters: 1000,
+		MaxCost:     100,
+		BufferItems: 64,
+	})
+	if err != nil {
+		panic(err)
+	}
+	store := NewRistretto(client, lib_store.WithSynchronousSet())
 
 	for k := 0.; k <= 10; k++ {
 		n := int(math.Pow(2, k))
@@ -47,12 +73,12 @@ func BenchmarkRistrettoGet(b *testing.B) {
 	if err != nil {
 		panic(err)
 	}
-	store := NewRistretto(client, nil)
+	store := NewRistretto(client)
 
 	key := "test"
 	value := []byte("value")
 
-	store.Set(ctx, key, value, nil)
+	store.Set(ctx, key, value)
 
 	for k := 0.; k <= 10; k++ {
 		n := int(math.Pow(2, k))

--- a/store/ristretto/ristretto_mock.go
+++ b/store/ristretto/ristretto_mock.go
@@ -86,3 +86,15 @@ func (mr *MockRistrettoClientInterfaceMockRecorder) SetWithTTL(key, value, cost,
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWithTTL", reflect.TypeOf((*MockRistrettoClientInterface)(nil).SetWithTTL), key, value, cost, ttl)
 }
+
+// Wait mocks base method.
+func (m *MockRistrettoClientInterface) Wait() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Wait")
+}
+
+// Wait indicates an expected call of Wait.
+func (mr *MockRistrettoClientInterfaceMockRecorder) Wait() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Wait", reflect.TypeOf((*MockRistrettoClientInterface)(nil).Wait))
+}

--- a/store/ristretto/ristretto_test.go
+++ b/store/ristretto/ristretto_test.go
@@ -177,6 +177,28 @@ func TestRistrettoSetWhenError(t *testing.T) {
 	assert.Equal(t, fmt.Errorf("An error has occurred while setting value '%v' on key '%v'", cacheValue, cacheKey), err)
 }
 
+func TestRistrettoSetWithSynchronousSet(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	cacheKey := "my-key"
+	cacheValue := []byte("my-cache-value")
+
+	client := NewMockRistrettoClientInterface(ctrl)
+	client.EXPECT().SetWithTTL(cacheKey, cacheValue, int64(7), 0*time.Second).Return(true)
+	client.EXPECT().Wait()
+
+	store := NewRistretto(client, lib_store.WithCost(7), lib_store.WithSynchronousSet())
+
+	// When
+	err := store.Set(ctx, cacheKey, cacheValue, lib_store.WithSynchronousSet())
+
+	// Then
+	assert.Nil(t, err)
+}
+
 func TestRistrettoSetWithTags(t *testing.T) {
 	// Given
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
Add configurable option to ristretto cache store to be able to wait/blocks until all buffered writes have been applied. 
ref: https://github.com/dgraph-io/ristretto/blob/main/cache.go#L219

Fixes : #207