### PR TITLE
avoid parallel running a load function for the same key #242

### DIFF
--- a/lib/cache/loadable.go
+++ b/lib/cache/loadable.go
@@ -52,7 +52,9 @@ func (c *LoadableCache[T]) setter() {
 
 	for item := range c.setChannel {
 		c.Set(context.Background(), item.key, item.value)
-		c.singleFlight.Forget(c.getCacheKey(item.key))
+
+		cacheKey := c.getCacheKey(item.key)
+		c.singleFlight.Forget(cacheKey)
 	}
 }
 

--- a/lib/go.mod
+++ b/lib/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	golang.org/x/exp v0.0.0-20221126150942-6ab00d035af9
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 )
 
 require (

--- a/lib/go.sum
+++ b/lib/go.sum
@@ -304,6 +304,8 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
used https://pkg.go.dev/golang.org/x/sync/singleflight to avoid parallel running of the loading function.
modified test to check the new behavior 