### PR TITLE
Create Hazelcast store from map instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,9 +258,12 @@ if err != nil {
     log.Fatalf("Failed to start client: %v", err)
 }
 
-hzMapName:= "gocache"
+hzMap, err := hzClient.GetMap(ctx, "gocache")
+if err != nil {
+    b.Fatalf("Failed to get map: %v", err)
+}
 
-hazelcastStore := hazelcast_store.NewHazelcast(hzClient, hzMapName)
+hazelcastStore := hazelcast_store.NewHazelcast(hzMap)
 
 cacheManager := cache.New[string](hazelcastStore)
 err := cacheManager.Set(ctx, "my-key", "my-value", store.WithExpiration(15*time.Second))

--- a/store/hazelcast/hazelcast_benchmark_test.go
+++ b/store/hazelcast/hazelcast_benchmark_test.go
@@ -18,7 +18,12 @@ func BenchmarkHazelcastSet(b *testing.B) {
 		b.Fatalf("Failed to start client: %v", err)
 	}
 
-	store := NewHazelcast(hzClient, "gocache")
+	hzMap, err := hzClient.GetMap(ctx, "gocache")
+	if err != nil {
+		b.Fatalf("Failed to get map: %v", err)
+	}
+
+	store := NewHazelcast(hzMap)
 
 	for k := 0.; k <= 10; k++ {
 		n := int(math.Pow(2, k))
@@ -40,7 +45,12 @@ func BenchmarkHazelcastGet(b *testing.B) {
 		b.Fatalf("Failed to start client: %v", err)
 	}
 
-	store := NewHazelcast(hzClient, "gocache")
+	hzMap, err := hzClient.GetMap(ctx, "gocache")
+	if err != nil {
+		b.Fatalf("Failed to get map: %v", err)
+	}
+
+	store := NewHazelcast(hzMap)
 
 	key := "test"
 	value := []byte("value")


### PR DESCRIPTION
After I got some insight into the Hazelcast client, I reconsidered the changes applied in #203. Creating a new Hazelcast map instance for each operation does not offer any benefits. Instead, we can safely use a single map instance for all operations, making the API clearer and more concise.