### PR TITLE
Add GetWithTTL() support to Bigcache store to fix ChainCache

### DIFF
--- a/store/bigcache/bigcache.go
+++ b/store/bigcache/bigcache.go
@@ -52,9 +52,13 @@ func (s *BigcacheStore) Get(_ context.Context, key any) (any, error) {
 	return item, err
 }
 
-// Not implemented for BigcacheStore
+// Even though Bigcache does not support a TTL, try our best to implement this
+// because it's needed by ChainCache -- if we just return an error, ChainCache
+// will never see any cache hits. Arbitrarily pick a 5 minute timeout since it's
+// not "too bad" or "too small".
 func (s *BigcacheStore) GetWithTTL(ctx context.Context, key any) (any, time.Duration, error) {
-	return nil, 0, errors.New("method not implemented for codec, use Get() instead")
+	result, err := s.Get(ctx, key)
+	return result, time.Minute * 5, err
 }
 
 // Set defines data in Bigcache for given key identifier

--- a/store/bigcache/bigcache.go
+++ b/store/bigcache/bigcache.go
@@ -55,7 +55,7 @@ func (s *BigcacheStore) Get(_ context.Context, key any) (any, error) {
 // Even though Bigcache does not support a TTL, try our best to implement this
 // because it's needed by ChainCache -- if we just return an error, ChainCache
 // will never see any cache hits. Arbitrarily pick a 5 minute timeout since it's
-// not "too bad" or "too small".
+// not "too big" or "too small".
 func (s *BigcacheStore) GetWithTTL(ctx context.Context, key any) (any, time.Duration, error) {
 	result, err := s.Get(ctx, key)
 	return result, time.Minute * 5, err

--- a/store/bigcache/bigcache_test.go
+++ b/store/bigcache/bigcache_test.go
@@ -78,9 +78,10 @@ func TestBigcacheGetWithTTL(t *testing.T) {
 
 	cacheKey := "my-key"
 	client := NewMockBigcacheClientInterface(ctrl)
+	client.EXPECT().Get(cacheKey).Return(nil, nil)
 	store := NewBigcache(client)
 
-	expectedErr := errors.New("method not implemented for codec, use Get() instead")
+	expectedErr := lib_store.NotFoundWithCause(errors.New("unable to retrieve data from bigcache"))
 
 	// When
 	value, _, err := store.GetWithTTL(ctx, cacheKey)


### PR DESCRIPTION
- Just proxy through to Get() with a static TTL
- Needed to support the ChainCache use-case