### PR TITLE
fix: improve error handling in ChainCache.Set method

### DIFF
--- a/lib/cache/chain.go
+++ b/lib/cache/chain.go
@@ -78,18 +78,10 @@ func (c *ChainCache[T]) Set(ctx context.Context, key any, object T, options ...s
 		err := cache.Set(ctx, key, object, options...)
 		if err != nil {
 			storeType := cache.GetCodec().GetStore().GetType()
-			errs = append(errs, fmt.Errorf("Unable to set item into cache with store '%s': %v", storeType, err))
+			errs = append(errs, fmt.Errorf("unable to set item into cache with store '%s': %w", storeType, err))
 		}
 	}
-	if len(errs) > 0 {
-		errStr := ""
-		for k, v := range errs {
-			errStr += fmt.Sprintf("error %d of %d: %v", k+1, len(errs), v.Error())
-		}
-		return errors.New(errStr)
-	}
-
-	return nil
+	return errors.Join(errs...)
 }
 
 // Delete removes a value from all available caches

--- a/lib/cache/chain_test.go
+++ b/lib/cache/chain_test.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -246,7 +245,8 @@ func TestChainSetWhenErrorOnSetting(t *testing.T) {
 
 	// Then
 	assert.Error(t, err)
-	assert.Equal(t, fmt.Sprintf("error 1 of 1: Unable to set item into cache with store 'store1': %s", expectedErr.Error()), err.Error())
+	assert.ErrorIs(t, err, expectedErr)
+	assert.ErrorContains(t, err, "unable to set item into cache with store 'store1'")
 }
 
 func TestChainDelete(t *testing.T) {
@@ -447,7 +447,8 @@ func TestChainSetWhenErrorInChain(t *testing.T) {
 	// When - Then
 	err := cache.Set(ctx, key, value, nil)
 
-	expErr := errors.New("error 1 of 1: Unable to set item into cache with store 'store1': an issue occurred with the cache")
 	// Then
-	assert.Equal(t, expErr, err)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, interError)
+	assert.ErrorContains(t, err, "unable to set item into cache with store 'store1'")
 }


### PR DESCRIPTION
Improvements to error handling:

* [`lib/cache/chain.go`](diffhunk://#diff-1c9bd527f5aa84131bfaf0887a142b434117515f5609e3453b61b839a7cfce38L81-R84): Modified the error formatting to use `%w` for wrapping errors and simplified the error aggregation by using `errors.Join`.

It will allow us to handle the underlying errors returned by `Set`.