### PR TITLE
feat: add TTL support for tags in Hazelcast store

### DIFF
--- a/store/hazelcast/hazelcast_test.go
+++ b/store/hazelcast/hazelcast_test.go
@@ -98,13 +98,36 @@ func TestHazelcastSetWithTags(t *testing.T) {
 
 	hzMap := NewMockHazelcastMapInterface(ctrl)
 	hzMap.EXPECT().SetWithTTL(ctx, cacheKey, cacheValue, time.Duration(0)).Return(nil)
-	hzMap.EXPECT().SetWithTTL(gomock.Any(), "gocache_tag_tag1", cacheKey, TagKeyExpiry).Return(nil)
+	hzMap.EXPECT().SetWithTTL(gomock.Any(), "gocache_tag_tag1", cacheKey, time.Duration(0)).Return(nil)
 	hzMap.EXPECT().Get(gomock.Any(), "gocache_tag_tag1").Return(nil, nil)
 
 	store := NewHazelcast(hzMap)
 
 	// When
 	err := store.Set(ctx, cacheKey, cacheValue, lib_store.WithTags([]string{"tag1"}))
+
+	// Then
+	assert.Nil(t, err)
+}
+
+func TestHazelcastSetWithTagsTTL(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	cacheKey := "my-key"
+	cacheValue := "my-cache-value"
+
+	hzMap := NewMockHazelcastMapInterface(ctrl)
+	hzMap.EXPECT().SetWithTTL(ctx, cacheKey, cacheValue, time.Duration(0)).Return(nil)
+	hzMap.EXPECT().SetWithTTL(gomock.Any(), "gocache_tag_tag1", cacheKey, 10*time.Second).Return(nil)
+	hzMap.EXPECT().Get(gomock.Any(), "gocache_tag_tag1").Return(nil, nil)
+
+	store := NewHazelcast(hzMap)
+
+	// When
+	err := store.Set(ctx, cacheKey, cacheValue, lib_store.WithTags([]string{"tag1"}), lib_store.WithTagsTTL(10*time.Second))
 
 	// Then
 	assert.Nil(t, err)


### PR DESCRIPTION
It modifies the handling of tag TTLs in the Hazelcast store to use the newly introduced `TagsTTL` option from #276