### PR TITLE
Fix pegasus module version

### DIFF
--- a/store/pegasus/go.mod
+++ b/store/pegasus/go.mod
@@ -1,6 +1,7 @@
 module github.com/eko/gocache/store/pegasus/v4
 
-go 1.22
+go 1.23.0
+
 toolchain go1.24.1
 
 require (

--- a/store/redis/redis.go
+++ b/store/redis/redis.go
@@ -90,15 +90,15 @@ func (s *RedisStore) Set(ctx context.Context, key any, value any, options ...lib
 }
 
 func (s *RedisStore) setTagsWithTTL(ctx context.Context, key any, tags []string, ttl time.Duration) {
-  for _, tag := range tags {
-    tagKey := fmt.Sprintf(RedisTagPattern, tag)
-    s.client.SAdd(ctx, tagKey, key.(string))
-    s.client.Expire(ctx, tagKey, ttl)
-  }
+	for _, tag := range tags {
+		tagKey := fmt.Sprintf(RedisTagPattern, tag)
+		s.client.SAdd(ctx, tagKey, key.(string))
+		s.client.Expire(ctx, tagKey, ttl)
+	}
 }
 
 func (s *RedisStore) setTags(ctx context.Context, key any, tags []string) {
-  s.setTagsWithTTL(ctx, key, tags, 720*time.Hour)
+	s.setTagsWithTTL(ctx, key, tags, 720*time.Hour)
 }
 
 // Delete removes data from Redis for given key identifier


### PR DESCRIPTION
It requires `go 1.23.0` after bumping `x/net` to `0.38.0` in #285

Fixes the error in CI workflow.
https://github.com/eko/gocache/actions/runs/14546559416/job/40812732156#step:4:20