### PR TITLE
TBD: feat: add generic serializer impl

### DIFF
--- a/lib/serializer/interface.go
+++ b/lib/serializer/interface.go
@@ -1,0 +1,6 @@
+package serializer
+
+type Serializer interface {
+	Marshal(any) ([]byte, error)
+	Unmarshal([]byte, any) error
+}

--- a/lib/serializer/serializer.go
+++ b/lib/serializer/serializer.go
@@ -1,0 +1,88 @@
+package serializer
+
+import (
+	"context"
+
+	"github.com/eko/gocache/lib/v4/cache"
+	lib_store "github.com/eko/gocache/lib/v4/store"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+var _ cache.CacheInterface[any] = (*SerializerCache[any])(nil)
+
+type SerializerCache[T any] struct {
+	cache      cache.CacheInterface[[]byte]
+	serializer Serializer
+}
+
+func New[T any](serializer Serializer, cacheInterface cache.CacheInterface[[]byte]) *SerializerCache[T] {
+	serializerCache := &SerializerCache[T]{
+		cache:      cacheInterface,
+		serializer: serializer,
+	}
+	return serializerCache
+}
+
+func (c *SerializerCache[T]) Get(ctx context.Context, key any) (T, error) {
+	var zero T
+
+	result, err := c.cache.Get(ctx, key)
+	if err != nil {
+		return zero, err
+	}
+
+	var returnObj T
+	err = c.serializer.Unmarshal(result, &returnObj)
+	if err != nil {
+		return zero, err
+	}
+
+	return returnObj, nil
+}
+
+func (c *SerializerCache[T]) Set(ctx context.Context, key any, object T, options ...lib_store.Option) error {
+	bytes, err := c.serializer.Marshal(object)
+	if err != nil {
+		return err
+	}
+
+	return c.cache.Set(ctx, key, bytes, options...)
+}
+
+func (c *SerializerCache[T]) Delete(ctx context.Context, key any) error {
+	return c.cache.Delete(ctx, key)
+}
+
+func (c *SerializerCache[T]) Invalidate(ctx context.Context, options ...lib_store.InvalidateOption) error {
+	return c.cache.Invalidate(ctx, options...)
+}
+
+func (c *SerializerCache[T]) Clear(ctx context.Context) error {
+	return c.cache.Clear(ctx)
+}
+
+func (c *SerializerCache[T]) GetType() string {
+	return "marshaler"
+}
+
+// TODO tests here
+
+// DefaultSerializer msgpack by default
+type DefaultSerializer struct {
+	MarshalFn   func(any) ([]byte, error)
+	UnmarshalFn func([]byte, any) error
+}
+
+func (c DefaultSerializer) Marshal(a any) ([]byte, error) {
+	if c.MarshalFn != nil {
+		return c.MarshalFn(a)
+	}
+	return msgpack.Marshal(a)
+}
+
+func (c DefaultSerializer) Unmarshal(bytes []byte, a any) error {
+	if c.UnmarshalFn != nil {
+		return c.UnmarshalFn(bytes, a)
+	}
+	return msgpack.Unmarshal(bytes, a)
+}

--- a/lib/serializer/serializer_test.go
+++ b/lib/serializer/serializer_test.go
@@ -1,0 +1,299 @@
+package serializer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	mockcache "github.com/eko/gocache/lib/v4/internal/mocks/cache"
+	"github.com/eko/gocache/lib/v4/store"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmihailenco/msgpack/v5"
+	"go.uber.org/mock/gomock"
+)
+
+type testCacheValue struct {
+	Hello string
+}
+
+func TestNew(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+
+	// When
+	serializer := New[testCacheValue](DefaultSerializer{}, cache)
+
+	// Then
+	assert.IsType(t, new(SerializerCache[testCacheValue]), serializer)
+	assert.Equal(t, cache, serializer.cache)
+}
+
+func TestGetWhenStoreReturnsSliceOfBytes(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	cacheValue := &testCacheValue{
+		Hello: "world",
+	}
+
+	cacheValueBytes, err := msgpack.Marshal(cacheValue)
+	if err != nil {
+		assert.Error(t, err)
+	}
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Get(ctx, "my-key").Return(cacheValueBytes, nil)
+
+	serializer := New[*testCacheValue](DefaultSerializer{}, cache)
+
+	// When
+	value, err := serializer.Get(ctx, "my-key")
+
+	// Then
+	assert.Nil(t, err)
+	assert.Equal(t, cacheValue, value)
+}
+
+func TestGetWhenUnmarshalingError(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Get(ctx, "my-key").Return([]byte("unknown-string"), nil)
+
+	serializer := New[*testCacheValue](DefaultSerializer{}, cache)
+
+	// When
+	value, err := serializer.Get(ctx, "my-key")
+
+	// Then
+	assert.NotNil(t, err)
+	assert.Nil(t, value)
+}
+
+func TestGetWhenNotFoundInStore(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	expectedErr := errors.New("unable to find item in store")
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Get(ctx, "my-key").Return(nil, expectedErr)
+
+	serializer := New[*testCacheValue](DefaultSerializer{}, cache)
+
+	// When
+	value, err := serializer.Get(ctx, "my-key")
+
+	// Then
+	assert.Equal(t, expectedErr, err)
+	assert.Nil(t, value)
+}
+
+func TestSetWhenStruct(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	cacheValue := &testCacheValue{
+		Hello: "world",
+	}
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Set(
+		ctx,
+		"my-key",
+		[]byte{0x81, 0xa5, 0x48, 0x65, 0x6c, 0x6c, 0x6f, 0xa5, 0x77, 0x6f, 0x72, 0x6c, 0x64},
+		store.OptionsMatcher{
+			Expiration: 5 * time.Second,
+		},
+	).Return(nil)
+
+	serializer := New[*testCacheValue](DefaultSerializer{}, cache)
+
+	// When
+	err := serializer.Set(ctx, "my-key", cacheValue, store.WithExpiration(5*time.Second))
+
+	// Then
+	assert.Nil(t, err)
+}
+
+func TestSetWhenString(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	cacheValue := "test"
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Set(
+		ctx,
+		"my-key",
+		[]byte{0xa4, 0x74, 0x65, 0x73, 0x74},
+		store.OptionsMatcher{
+			Expiration: 5 * time.Second,
+		},
+	).Return(nil)
+
+	serializer := New[string](DefaultSerializer{}, cache)
+
+	// When
+	err := serializer.Set(ctx, "my-key", cacheValue, store.WithExpiration(5*time.Second))
+
+	// Then
+	assert.Nil(t, err)
+}
+
+func TestSetWhenError(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	cacheValue := "test"
+
+	expectedErr := errors.New("an unexpected error occurred")
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Set(
+		ctx,
+		"my-key",
+		[]byte{0xa4, 0x74, 0x65, 0x73, 0x74},
+		store.OptionsMatcher{Expiration: 5 * time.Second},
+	).Return(expectedErr)
+
+	serializer := New[string](DefaultSerializer{}, cache)
+
+	// When
+	err := serializer.Set(ctx, "my-key", cacheValue, store.WithExpiration(5*time.Second))
+
+	// Then
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestDelete(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Delete(ctx, "my-key").Return(nil)
+
+	serializer := New[string](DefaultSerializer{}, cache)
+
+	// When
+	err := serializer.Delete(ctx, "my-key")
+
+	// Then
+	assert.Nil(t, err)
+}
+
+func TestDeleteWhenError(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	expectedErr := errors.New("unable to delete key")
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Delete(ctx, "my-key").Return(expectedErr)
+
+	serializer := New[string](DefaultSerializer{}, cache)
+
+	// When
+	err := serializer.Delete(ctx, "my-key")
+
+	// Then
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestInvalidate(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Invalidate(ctx, store.InvalidateOptionsMatcher{
+		Tags: []string{"tag1"},
+	}).Return(nil)
+
+	serializer := New[string](DefaultSerializer{}, cache)
+
+	// When
+	err := serializer.Invalidate(ctx, store.WithInvalidateTags([]string{"tag1"}))
+
+	// Then
+	assert.Nil(t, err)
+}
+
+func TestInvalidatingWhenError(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	expectedErr := errors.New("unexpected error when invalidating data")
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Invalidate(ctx, store.InvalidateOptionsMatcher{Tags: []string{"tag1"}}).Return(expectedErr)
+
+	serializer := New[string](DefaultSerializer{}, cache)
+
+	// When
+	err := serializer.Invalidate(ctx, store.WithInvalidateTags([]string{"tag1"}))
+
+	// Then
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestClear(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Clear(ctx).Return(nil)
+
+	serializer := New[string](DefaultSerializer{}, cache)
+
+	// When
+	err := serializer.Clear(ctx)
+
+	// Then
+	assert.Nil(t, err)
+}
+
+func TestClearWhenError(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
+
+	ctx := context.Background()
+
+	expectedErr := errors.New("an unexpected error occurred")
+
+	cache := mockcache.NewMockCacheInterface[[]byte](ctrl)
+	cache.EXPECT().Clear(ctx).Return(expectedErr)
+
+	serializer := New[string](DefaultSerializer{}, cache)
+
+	// When
+	err := serializer.Clear(ctx)
+
+	// Then
+	assert.Equal(t, expectedErr, err)
+}


### PR DESCRIPTION
To address the issue in #72 https://github.com/eko/gocache/issues/72#issuecomment-1670815311, a generic Marshaler implementation has been added.

Outstanding tasks:

- [ ] Test cases for Serializer
- [ ] Compatibility tests with Loadable

Items for discussion:

1. Should Marshaler be directly replaced instead of creating a new Serializer?
2. The original implementation supported both `[]byte` and `string` types; is continued support necessary?
3. Are the parameters for this constructor method appropriate?
4. Design question: Should the StoreInterface itself determine whether to serialize? After CacheInterface supports generics, users would expect to directly retrieve the corresponding object T, rather than concerning themselves with how object T is converted into the format supported by each StoreInterface, or how to deserialize from the `string` or `[]byte` returned by each StoreInterface back into object T.

> Translated from chinese 
> 为了解决 #72 中的问题  https://github.com/eko/gocache/issues/72#issuecomment-1670815311 增加泛型的 Marshaler 实现
> 
> 未完成的工作：
> 
> - [ ] Serializer 的测试用例
> - [ ] 与 Loadable 的兼容性测试
> 
> 待讨论项：
> 
> 1. 是否应直接替换 Marshaler 而非新建一个 Serializer 
> 2. 原来的实现中兼容了类型为 []byte 和 string 的两种情况，是否需要继续支持
> 3. 这个构造方法的参数是否合适
> 4. 设计问题：序列化与否是否应该由 StoreInterface 自己决定？CacheInterface 支持泛型后，用户期望的应该是直接能拿到对应的 obj T ，而不是 obj T 怎么转为每个 StoreInterface 支持的格式，怎么从每个 StoreInterface 返回的 string 或 []byte 反序列化回 obj T