### PR TITLE
feat: add TTL support for tags in Memcache store

### DIFF
--- a/store/memcache/memcache.go
+++ b/store/memcache/memcache.go
@@ -94,13 +94,17 @@ func (s *MemcacheStore) Set(ctx context.Context, key any, value any, options ...
 	}
 
 	if tags := opts.Tags; len(tags) > 0 {
-		s.setTags(ctx, key, tags)
+		ttl := opts.TagsTTL
+		if ttl == 0 {
+			ttl = TagKeyExpiry
+		}
+		s.setTags(ctx, key, tags, ttl)
 	}
 
 	return nil
 }
 
-func (s *MemcacheStore) setTags(ctx context.Context, key any, tags []string) {
+func (s *MemcacheStore) setTags(ctx context.Context, key any, tags []string, ttl time.Duration) {
 	group, ctx := errgroup.WithContext(ctx)
 	for _, tag := range tags {
 		currentTag := tag
@@ -109,7 +113,7 @@ func (s *MemcacheStore) setTags(ctx context.Context, key any, tags []string) {
 
 			var err error
 			for i := 0; i < 3; i++ {
-				if err = s.addKeyToTagValue(tagKey, key); err == nil {
+				if err = s.addKeyToTagValue(tagKey, key, ttl); err == nil {
 					return nil
 				}
 				// loop to retry any failure (including race conditions)
@@ -122,7 +126,7 @@ func (s *MemcacheStore) setTags(ctx context.Context, key any, tags []string) {
 	group.Wait()
 }
 
-func (s *MemcacheStore) addKeyToTagValue(tagKey string, key any) error {
+func (s *MemcacheStore) addKeyToTagValue(tagKey string, key any, ttl time.Duration) error {
 	var (
 		cacheKeys = []string{}
 		result    *memcache.Item
@@ -152,14 +156,14 @@ func (s *MemcacheStore) addKeyToTagValue(tagKey string, key any) error {
 		return s.client.Add(&memcache.Item{
 			Key:        tagKey,
 			Value:      newVal,
-			Expiration: int32(TagKeyExpiry.Seconds()),
+			Expiration: int32(ttl.Seconds()),
 		})
 	}
 
 	// update existing value
 	// using CompareAndSwap to ensure not to run over writes between Get and here
 	result.Value = newVal
-	result.Expiration = int32(TagKeyExpiry.Seconds())
+	result.Expiration = int32(ttl.Seconds())
 	return s.client.CompareAndSwap(result)
 }
 

--- a/store/memcache/memcache_test.go
+++ b/store/memcache/memcache_test.go
@@ -251,6 +251,69 @@ func TestMemcacheSetWithTags(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestMemcacheSetWithTagsAndTagsTTL(t *testing.T) {
+	// Given
+	ctx := context.Background()
+
+	cacheKey := "my-key"
+	cacheValue := []byte("my-cache-value")
+
+	tagKey := "gocache_tag_tag1"
+
+	client := NewMockMemcacheClientInterface(t)
+	client.EXPECT().Set(mock.Anything).Return(nil)
+	client.EXPECT().Get(tagKey).Return(nil, memcache.ErrCacheMiss)
+	client.EXPECT().Add(&memcache.Item{
+		Key:        tagKey,
+		Value:      []byte(cacheKey),
+		Expiration: int32((5 * time.Minute).Seconds()),
+	}).Return(nil)
+
+	store := NewMemcache(client)
+
+	// When
+	err := store.Set(ctx, cacheKey, cacheValue,
+		lib_store.WithTags([]string{"tag1"}),
+		lib_store.WithTagsTTL(5*time.Minute),
+	)
+
+	// Then
+	assert.Nil(t, err)
+}
+
+func TestMemcacheSetWithTagsAndTagsTTLWhenTagExists(t *testing.T) {
+	// Given
+	ctx := context.Background()
+
+	cacheKey := "my-key"
+	cacheValue := []byte("my-cache-value")
+
+	tagKey := "gocache_tag_tag1"
+
+	existing := &memcache.Item{
+		Value: []byte("a-second-key"),
+	}
+
+	client := NewMockMemcacheClientInterface(t)
+	client.EXPECT().Set(mock.Anything).Return(nil)
+	client.EXPECT().Get(tagKey).Return(existing, nil)
+	client.EXPECT().CompareAndSwap(&memcache.Item{
+		Value:      []byte("a-second-key,my-key"),
+		Expiration: int32((5 * time.Minute).Seconds()),
+	}).Return(nil)
+
+	store := NewMemcache(client)
+
+	// When
+	err := store.Set(ctx, cacheKey, cacheValue,
+		lib_store.WithTags([]string{"tag1"}),
+		lib_store.WithTagsTTL(5*time.Minute),
+	)
+
+	// Then
+	assert.Nil(t, err)
+}
+
 func TestMemcacheSetWithTagsWhenAlreadyInserted(t *testing.T) {
 	// Given
 	ctx := context.Background()

--- a/store/memcache/memcache_test.go
+++ b/store/memcache/memcache_test.go
@@ -281,7 +281,7 @@ func TestMemcacheSetWithTagsAndTagsTTL(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestMemcacheSetWithTagsAndTagsTTLWhenTagExists(t *testing.T) {
+func TestMemcacheSetWithTagsWhenTagExists(t *testing.T) {
 	// Given
 	ctx := context.Background()
 

--- a/store/redis/redis.go
+++ b/store/redis/redis.go
@@ -26,6 +26,8 @@ const (
 	RedisType = "redis"
 	// RedisTagPattern represents the tag pattern to be used as a key in specified storage
 	RedisTagPattern = "gocache_tag_%s"
+
+	TagKeyExpiry = 720 * time.Hour
 )
 
 // RedisStore is a store for Redis
@@ -79,26 +81,22 @@ func (s *RedisStore) Set(ctx context.Context, key any, value any, options ...lib
 	}
 
 	if tags := opts.Tags; len(tags) > 0 {
-		if ttl := opts.TagsTTL; ttl == 0 {
-			s.setTags(ctx, key, tags)
-		} else {
-			s.setTagsWithTTL(ctx, key, tags, ttl)
+		ttl := opts.TagsTTL
+		if ttl == 0 {
+			ttl = TagKeyExpiry
 		}
+		s.setTags(ctx, key, tags, ttl)
 	}
 
 	return nil
 }
 
-func (s *RedisStore) setTagsWithTTL(ctx context.Context, key any, tags []string, ttl time.Duration) {
+func (s *RedisStore) setTags(ctx context.Context, key any, tags []string, ttl time.Duration) {
 	for _, tag := range tags {
 		tagKey := fmt.Sprintf(RedisTagPattern, tag)
 		s.client.SAdd(ctx, tagKey, key.(string))
 		s.client.Expire(ctx, tagKey, ttl)
 	}
-}
-
-func (s *RedisStore) setTags(ctx context.Context, key any, tags []string) {
-	s.setTagsWithTTL(ctx, key, tags, 720*time.Hour)
 }
 
 // Delete removes data from Redis for given key identifier

--- a/store/redis/redis_test.go
+++ b/store/redis/redis_test.go
@@ -146,7 +146,7 @@ func TestRedisSetWithTags(t *testing.T) {
 	client := NewMockRedisClientInterface(ctrl)
 	client.EXPECT().Set(ctx, cacheKey, cacheValue, time.Duration(0)).Return(&redis.StatusCmd{})
 	client.EXPECT().SAdd(ctx, "gocache_tag_tag1", "my-key").Return(&redis.IntCmd{})
-	client.EXPECT().Expire(ctx, "gocache_tag_tag1", 720*time.Hour).Return(&redis.BoolCmd{})
+	client.EXPECT().Expire(ctx, "gocache_tag_tag1", TagKeyExpiry).Return(&redis.BoolCmd{})
 
 	store := NewRedis(client)
 
@@ -157,27 +157,30 @@ func TestRedisSetWithTags(t *testing.T) {
 	assert.Nil(t, err)
 }
 
-func TestRedisSetWithTagsWithTTL(t *testing.T) {
-  // Given
-  ctrl := gomock.NewController(t)
+func TestRedisSetWithTagsAndTagsTTL(t *testing.T) {
+	// Given
+	ctrl := gomock.NewController(t)
 
-  ctx := context.Background()
+	ctx := context.Background()
 
-  cacheKey := "my-key"
-  cacheValue := "my-cache-value"
+	cacheKey := "my-key"
+	cacheValue := "my-cache-value"
 
-  client := NewMockRedisClientInterface(ctrl)
-  client.EXPECT().Set(ctx, cacheKey, cacheValue, time.Duration(0)).Return(&redis.StatusCmd{})
-  client.EXPECT().SAdd(ctx, "gocache_tag_tag1", "my-key").Return(&redis.IntCmd{})
-  client.EXPECT().Expire(ctx, "gocache_tag_tag1", time.Hour).Return(&redis.BoolCmd{})
+	client := NewMockRedisClientInterface(ctrl)
+	client.EXPECT().Set(ctx, cacheKey, cacheValue, time.Duration(0)).Return(&redis.StatusCmd{})
+	client.EXPECT().SAdd(ctx, "gocache_tag_tag1", "my-key").Return(&redis.IntCmd{})
+	client.EXPECT().Expire(ctx, "gocache_tag_tag1", time.Hour).Return(&redis.BoolCmd{})
 
-  store := NewRedis(client)
+	store := NewRedis(client)
 
-  // When
-  err := store.Set(ctx, cacheKey, cacheValue, []lib_store.Option{lib_store.WithTags([]string{"tag1"}), lib_store.WithTagsTTL(time.Hour)}...)
+	// When
+	err := store.Set(ctx, cacheKey, cacheValue,
+		lib_store.WithTags([]string{"tag1"}),
+		lib_store.WithTagsTTL(time.Hour),
+	)
 
-  // Then
-  assert.Nil(t, err)
+	// Then
+	assert.Nil(t, err)
 }
 
 func TestRedisDelete(t *testing.T) {


### PR DESCRIPTION
Fixes #304.

`WithTagsTTL` was added in #276 (Redis) and back-filled to Hazelcast in #283, but never wired through the Memcache store — `opts.TagsTTL` was accepted yet ignored, and tag keys always used the hardcoded `TagKeyExpiry` (720h).

This PR threads `opts.TagsTTL` through `setTags` → `addKeyToTagValue`, defaulting to `TagKeyExpiry` when zero so existing behavior is preserved. Two new tests cover the Add and CAS paths with a custom TTL.

Also includes a small drive-by cleanup in the Redis store: collapses `setTags`/`setTagsWithTTL` into a single `setTags(..., ttl)` matching the new Memcache shape, introduces a `TagKeyExpiry` constant, and aligns test naming with the Memcache tests. No behavior change.