### PR TITLE
fix(memcache): refresh tag TTL when re-Setting an existing (key, tag)

### DIFF
--- a/store/memcache/memcache.go
+++ b/store/memcache/memcache.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -136,14 +137,9 @@ func (s *MemcacheStore) addKeyToTagValue(tagKey string, key any) error {
 		return err
 	}
 
-	for _, cacheKey := range cacheKeys {
-		// if key already exists, nothing to do
-		if cacheKey == key.(string) {
-			return nil
-		}
+	if !slices.Contains(cacheKeys, key.(string)) {
+		cacheKeys = append(cacheKeys, key.(string))
 	}
-
-	cacheKeys = append(cacheKeys, key.(string))
 
 	newVal := []byte(strings.Join(cacheKeys, ","))
 

--- a/store/memcache/memcache_test.go
+++ b/store/memcache/memcache_test.go
@@ -263,6 +263,10 @@ func TestMemcacheSetWithTagsWhenAlreadyInserted(t *testing.T) {
 	client.EXPECT().Get("gocache_tag_tag1").Return(&memcache.Item{
 		Value: []byte("my-key,a-second-key"),
 	}, nil)
+	client.EXPECT().CompareAndSwap(&memcache.Item{
+		Value:      []byte("my-key,a-second-key"),
+		Expiration: int32(TagKeyExpiry.Seconds()),
+	}).Return(nil)
 
 	store := NewMemcache(client)
 


### PR DESCRIPTION
Fixes #305.

`addKeyToTagValue` returned early when the cache key was already in the tag's key list, skipping the `CompareAndSwap` that would have refreshed the tag's `Expiration`. As a result, tag-based `Invalidate` silently missed keys that were still being actively written, once the original tag TTL elapsed — diverging from the Redis store, which refreshes the tag TTL on every `Set` via an unconditional `Expire` after `SAdd`.

Replaces the manual loop + early return with `slices.Contains`: the duplicate append is still skipped, but the function now falls through to the `CompareAndSwap` so `Expiration` is refreshed regardless of whether the list contents changed. The existing `TestMemcacheSetWithTagsWhenAlreadyInserted` was updated to expect the `CompareAndSwap` and now acts as a regression test for the behavior.