### PR TITLE
cache(chain): return an error from Get when no caches are configured

### DIFF
--- a/lib/cache/chain.go
+++ b/lib/cache/chain.go
@@ -57,6 +57,10 @@ func (c *ChainCache[T]) setter() {
 // Get returns the object stored in cache if it exists
 func (c *ChainCache[T]) Get(ctx context.Context, key any) (T, error) {
 	var object T
+	if len(c.caches) == 0 {
+		return object, errors.New("no cache configured in chain")
+	}
+
 	var err error
 	var ttl time.Duration
 

--- a/lib/cache/chain_test.go
+++ b/lib/cache/chain_test.go
@@ -168,6 +168,15 @@ func TestChainGetWhenNotAvailableInAnyCache(t *testing.T) {
 	assert.Equal(t, nil, value)
 }
 
+func TestChainGetWithNoCachesReturnsError(t *testing.T) {
+	cache := NewChain[[]byte]()
+
+	value, err := cache.Get(context.Background(), "my-key")
+
+	assert.Nil(t, value)
+	assert.ErrorContains(t, err, "no cache configured")
+}
+
 func TestChainSet(t *testing.T) {
 	// Given
 	ctrl := gomock.NewController(t)


### PR DESCRIPTION
If a ChainCache is built with no underlying caches, \`Get\` returned the zero value of T with a nil error, which looks like a cache hit on a default-constructed value. \`ChainCache[[]byte].Get\` returned a zero-length \`[]byte\` and no error, so callers had no way to tell that nothing was actually cached.

Guard the empty-caches case so callers see a real error.

Closes #281.